### PR TITLE
Update 'Union' with use of more precise proof

### DIFF
--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -54,8 +54,6 @@ import           TcSMonad hiding (tcLookupClass)
 import           TyCoRep (Type (..))
 import           Type
 
-import           Outputable
-
 
 polysemyInternalUnion :: ModuleName
 polysemyInternalUnion = mkModuleName "Polysemy.Internal.Union"

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -52,6 +52,8 @@ import           TcSMonad hiding (tcLookupClass)
 import           TyCoRep (Type (..))
 import           Type
 
+import           Outputable
+
 
 polysemyInternalUnion :: ModuleName
 polysemyInternalUnion = mkModuleName "Polysemy.Internal.Union"
@@ -60,7 +62,7 @@ fundepPlugin :: TcPlugin
 fundepPlugin = TcPlugin
     { tcPluginInit = do
         md <- lookupModule polysemyInternalUnion (fsLit "polysemy")
-        monadEffectTcNm <- lookupName md (mkTcOcc "Find")
+        monadEffectTcNm <- lookupName md (mkTcOcc "Member'")
         (,) <$> tcPluginIO (newIORef S.empty)
             <*> tcLookupClass monadEffectTcNm
     , tcPluginSolve = solveFundep
@@ -69,7 +71,7 @@ fundepPlugin = TcPlugin
 allMonadEffectConstraints :: Class -> [Ct] -> [(CtLoc, (Type, Type, Type))]
 allMonadEffectConstraints cls cts =
     [ (ctLoc cd, (effName, eff, r))
-    | cd@CDictCan{cc_class = cls', cc_tyargs = [_, r, eff]} <- cts
+    | cd@CDictCan{cc_class = cls', cc_tyargs = [eff, r]} <- cts
     , cls == cls'
     , let effName = getEffName eff
     ]

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -273,8 +273,8 @@ raiseUnder :: ∀ e2 e1 r a. Sem (e1 ': r) a -> Sem (e1 ': e2 ': r) a
 raiseUnder = hoistSem $ hoist raiseUnder_b . weakenUnder
   where
     weakenUnder :: ∀ m x. Union (e1 ': r) m x -> Union (e1 ': e2 ': r) m x
-    weakenUnder (Union SZ a) = Union SZ a
-    weakenUnder (Union (SS n) a) = Union (SS (SS n)) a
+    weakenUnder (Union Here   a) = Union Here        a
+    weakenUnder (Union (In p) a) = Union (In $ In p) a
     {-# INLINE weakenUnder #-}
 {-# INLINE raiseUnder #-}
 
@@ -291,8 +291,8 @@ raiseUnder2 :: ∀ e2 e3 e1 r a. Sem (e1 ': r) a -> Sem (e1 ': e2 ': e3 ': r) a
 raiseUnder2 = hoistSem $ hoist raiseUnder2_b . weakenUnder2
   where
     weakenUnder2 ::  ∀ m x. Union (e1 ': r) m x -> Union (e1 ': e2 ': e3 ': r) m x
-    weakenUnder2 (Union SZ a) = Union SZ a
-    weakenUnder2 (Union (SS n) a) = Union (SS (SS (SS n))) a
+    weakenUnder2 (Union Here   a) = Union Here             a
+    weakenUnder2 (Union (In p) a) = Union (In $ In $ In p) a
     {-# INLINE weakenUnder2 #-}
 {-# INLINE raiseUnder2 #-}
 
@@ -309,8 +309,8 @@ raiseUnder3 :: ∀ e2 e3 e4 e1 r a. Sem (e1 ': r) a -> Sem (e1 ': e2 ': e3 ': e4
 raiseUnder3 = hoistSem $ hoist raiseUnder3_b . weakenUnder3
   where
     weakenUnder3 ::  ∀ m x. Union (e1 ': r) m x -> Union (e1 ': e2 ': e3 ': e4 ': r) m x
-    weakenUnder3 (Union SZ a) = Union SZ a
-    weakenUnder3 (Union (SS n) a) = Union (SS (SS (SS (SS n)))) a
+    weakenUnder3 (Union Here   a) = Union Here                  a
+    weakenUnder3 (Union (In p) a) = Union (In $ In $ In $ In p) a
     {-# INLINE weakenUnder3 #-}
 {-# INLINE raiseUnder3 #-}
 

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -37,12 +37,12 @@ import Polysemy.Internal.Effect
 import Polysemy.Internal.CustomErrors
 #endif
 
--- TOOD: move into 'CustomErrors'
+-- TODO: move into 'CustomErrors'
 import GHC.TypeLits
 
 
 ------------------------------------------------------------------------------
--- | Kind of effect datatype.
+-- | Kind of effect type constructor.
 type Eff = (Type -> Type) -> Type -> Type
 
 ------------------------------------------------------------------------------
@@ -61,7 +61,6 @@ data Elem :: Eff -> [Eff] -> Type where
   In   :: Elem e es -> Elem e (d ': es)
 
 ------------------------------------------------------------------------------
--- TODO: some docs
 data Yo e m a where
   Yo :: Functor f
      => e m a
@@ -87,7 +86,6 @@ instance Effect (Yo e) where
   {-# INLINE hoist #-}
 
 ------------------------------------------------------------------------------
--- TODO: some docs
 liftYo :: Functor m => e m a -> Yo e m a
 liftYo e = Yo e (Identity ())
                 (fmap Identity . runIdentity)

--- a/test/FusionSpec.hs
+++ b/test/FusionSpec.hs
@@ -30,7 +30,7 @@ spec :: Spec
 spec = do
   describe "fusion" $ do
     it "Union proofs should simplify" $ do
-      shouldSucceed $(inspectTest $ 'countDown `hasNoType` ''SNat)
+      shouldSucceed $(inspectTest $ 'countDown `hasNoType` ''Elem)
 
     it "internal uses of StateT should simplify" $ do
       shouldSucceed $(inspectTest $ 'countDown `doesNotUse` ''S.StateT)


### PR DESCRIPTION
Use of more precise:
```hs
data Elem :: Eff -> [Eff] -> Type where
  Here ::              Elem e (e ': es)
  In   :: Elem e es -> Elem e (d ': es)
```
instead of `Nat`+`SNat` allows us to prove important properties and makes implementation a little bit simpler, e.g.:
```hs
absurdU :: Union '[] m a -> a
absurdU = absurdU
```
can now be proved with `EmptyCase`:
```hs
absurdU (Union p  _) = case p of {}
```
TODO:
- [ ] Decide on custom type errors
- [ ] Make fundep plugin work again