### PR TITLE
GlobalState that safely runs under bracket

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -90,7 +90,7 @@ tests:
     - hspec-discover >= 2.0
     dependencies:
     - polysemy
-    - inspection-testing >= 0.4.2.1 && < 0.5
+    - inspection-testing >= 0.4.2 && < 0.5
     - hspec >= 2.6.0 && < 3
     - doctest >= 0.16.0.1 && < 0.17
 

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -43,7 +43,7 @@ tests:
     - polysemy-plugin
     - hspec >= 2.6.0 && < 3
     - should-not-typecheck >= 2.1.0 && < 3
-    - inspection-testing >= 0.4.2.1 && < 0.5
+    - inspection-testing >= 0.4.2 && < 0.5
 
 default-extensions:
   - DataKinds

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 67eaa9259909a5401e1bbdf179fc3263ec3b57afd9951ae709d347f390e9c541
+-- hash: d6541c6630b0beeaad870e361e1382face77df6d5864cd4b9b098d9b87697121
 
 name:           polysemy-plugin
 version:        0.2.1.0
@@ -71,7 +71,7 @@ test-suite polysemy-plugin-test
     , ghc >=8.4.4 && <9
     , ghc-tcplugins-extra >=0.3 && <0.4
     , hspec >=2.6.0 && <3
-    , inspection-testing >=0.4.2.1 && <0.5
+    , inspection-testing >=0.4.2 && <0.5
     , polysemy
     , polysemy-plugin
     , should-not-typecheck >=2.1.0 && <3

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3bb11d1562f0640e892b918e3de6086196562200410a660b14851704b64175a0
+-- hash: 4d6c637769c9136844862d03d9971011647b7615fb1767c3b096a1dcae8dc069
 
 name:           polysemy
 version:        0.4.0.0
@@ -39,9 +39,11 @@ flag error-messages
 
 library
   exposed-modules:
+      Data.AnyStore
       Polysemy
       Polysemy.Error
       Polysemy.Fixpoint
+      Polysemy.GlobalState
       Polysemy.Input
       Polysemy.Internal
       Polysemy.Internal.Combinators
@@ -99,6 +101,7 @@ test-suite polysemy-test
       BracketSpec
       DoctestSpec
       FusionSpec
+      GlobalStateSpec
       HigherOrderSpec
       InspectorSpec
       OutputSpec
@@ -117,7 +120,7 @@ test-suite polysemy-test
     , doctest >=0.16.0.1 && <0.17
     , first-class-families >=0.5.0.0 && <0.6
     , hspec >=2.6.0 && <3
-    , inspection-testing >=0.4.2.1 && <0.5
+    , inspection-testing >=0.4.2 && <0.5
     , mtl >=2.2.2 && <3
     , polysemy
     , syb >=0.7 && <0.8

--- a/src/Data/AnyStore.hs
+++ b/src/Data/AnyStore.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE RoleAnnotations #-}
+
+module Data.AnyStore
+  ( AnyStore ()
+  , Key ()
+  , emptyS
+  , allocS
+  , getS
+  , putS
+  , modifyS
+  , freeS
+  , fiddleKey
+  ) where
+
+
+import qualified Data.IntMap.Strict as IM
+import           Data.Kind
+import           GHC.Exts
+import           Unsafe.Coerce
+
+
+data AnyStore (p :: Type) = AnyStore
+  { _sNextId :: Int
+  , _sData   :: IM.IntMap Any
+  }
+
+newtype Key (p :: Type) (a :: Type) = Key Int
+  deriving (Eq, Ord)
+
+fiddleKey :: Key p a -> Key p' a
+fiddleKey (Key k) = Key k
+
+type role Key phantom representational
+
+
+emptyS :: AnyStore p
+emptyS = AnyStore 0 IM.empty
+
+allocS :: forall p s. s -> AnyStore p -> (AnyStore p, Key p s)
+allocS s (AnyStore next d) =
+  ( AnyStore (next + 1) $ IM.insert next (unsafeCoerce s) d
+  , Key next
+  )
+
+getS :: Key p s -> AnyStore p -> s
+getS (Key k) (AnyStore _ d)  = unsafeCoerce (d IM.! k)
+
+putS :: Key p s -> s -> AnyStore p -> AnyStore p
+putS (Key k) s (AnyStore n d) = AnyStore n $ IM.insert k (unsafeCoerce s) d
+
+modifyS :: Key p s -> (s -> s) -> AnyStore p -> AnyStore p
+modifyS k f d = putS k (f $! getS k d) d
+
+freeS :: Key p s -> AnyStore p -> AnyStore p
+freeS (Key k) (AnyStore n d) = AnyStore n $ IM.delete k d
+

--- a/src/Polysemy/GlobalState.hs
+++ b/src/Polysemy/GlobalState.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE BlockArguments  #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Polysemy.GlobalState
+  ( -- * Effect
+    GlobalState (..)
+
+    -- * Actions
+  , allocate
+  , getGlobal
+  , putGlobal
+  , modifyGlobal
+
+    -- * Interpretations
+  , runGlobalState
+  , runGlobalStateInIO
+
+    -- * Interpretations for Other Effects
+  , runStateAsGlobal
+  ) where
+
+import Data.AnyStore
+import Data.IORef
+import GHC.Exts
+import Polysemy
+import Polysemy.State
+import System.IO.Unsafe
+
+
+
+data GlobalState m a where
+  Allocate :: a -> (forall p. Key p a -> m b) -> GlobalState m b
+  GetGlobal :: Key p a -> GlobalState m a
+  PutGlobal :: Key p a -> a -> GlobalState m ()
+
+makeSem ''GlobalState
+
+
+modifyGlobal :: Member GlobalState r => (forall p. Key p s) -> (s -> s) -> Sem r ()
+modifyGlobal k f = getGlobal k >>= putGlobal k . f
+
+runStateAsGlobal :: forall s r a. Member GlobalState r => s -> Sem (State s ': r) a -> Sem r a
+runStateAsGlobal s m = allocate s $ \key ->
+  interpret
+    ( \case
+        Get    -> getGlobal key
+        Put s' -> putGlobal key s'
+    ) m
+
+
+runGlobalState :: Sem (GlobalState ': r) a -> Sem r a
+runGlobalState = evalState @(AnyStore Any) emptyS . reinterpretH \case
+  Allocate a f -> do
+    (store', key) <- gets $ allocS @Any a
+    key' <- pureT key
+    put store'
+    f' <- bindT f
+    r <- raise $ runGlobalState $ f' key'
+    modify' $ freeS key
+    pure r
+  GetGlobal key -> pureT =<< gets (getS @Any $ fiddleKey key)
+  PutGlobal key a -> do
+    modify' $ putS @Any (fiddleKey key) a
+    getInitialStateT
+
+
+runGlobalStateInIO :: Member (Lift IO) r => Sem (GlobalState ': r) a -> Sem r a
+runGlobalStateInIO = interpretH $ \case
+  Allocate a f -> do
+    key <- sendM
+         . atomicModifyIORef' unsafeGlobalIOAnyStore
+         $ allocS a
+    key' <- pureT key
+    f' <- bindT f
+    r <- raise $ runGlobalStateInIO $ f' key'
+    sendM $ atomicModifyIORef'Void unsafeGlobalIOAnyStore $ freeS key
+    pure r
+  GetGlobal key -> do
+    d <- sendM $ readIORef unsafeGlobalIOAnyStore
+    pureT $ getS (fiddleKey key) d
+  PutGlobal key a -> do
+    sendM . atomicModifyIORef'Void unsafeGlobalIOAnyStore $ putS (fiddleKey key) a
+    getInitialStateT
+
+
+atomicModifyIORef'Void :: IORef a -> (a -> a) -> IO ()
+atomicModifyIORef'Void ref f =
+  atomicModifyIORef' ref $ \a -> (f a, ())
+
+unsafeGlobalIOAnyStore :: IORef (AnyStore Any)
+unsafeGlobalIOAnyStore =
+  unsafePerformIO $ newIORef emptyS
+{-# NOINLINE unsafeGlobalIOAnyStore #-}
+

--- a/src/Polysemy/State.hs
+++ b/src/Polysemy/State.hs
@@ -9,9 +9,11 @@ module Polysemy.State
   , gets
   , put
   , modify
+  , modify'
 
     -- * Interpretations
   , runState
+  , evalState
   , runLazyState
   , runStateInIORef
 
@@ -54,6 +56,12 @@ modify f = do
   put $ f s
 {-# INLINABLE modify #-}
 
+modify' :: Member (State s) r => (s -> s) -> Sem r ()
+modify' f = do
+  s <- get
+  put $! f s
+{-# INLINABLE modify' #-}
+
 
 ------------------------------------------------------------------------------
 -- | Run a 'State' effect with local state.
@@ -62,6 +70,13 @@ runState = stateful $ \case
   Get   -> \s -> pure (s, s)
   Put s -> const $ pure (s, ())
 {-# INLINE[3] runState #-}
+
+
+------------------------------------------------------------------------------
+-- | Run a 'State' effect with local state, ignoring the resulting value.
+-- TODO(sandy): exec and also lazy versions
+evalState :: s -> Sem (State s ': r) a -> Sem r a
+evalState s = fmap snd . runState s
 
 
 ------------------------------------------------------------------------------

--- a/test/GlobalStateSpec.hs
+++ b/test/GlobalStateSpec.hs
@@ -1,0 +1,44 @@
+module GlobalStateSpec where
+
+import Test.Hspec
+import Polysemy
+import Polysemy.State
+import Polysemy.GlobalState
+import Polysemy.Resource
+
+
+forgetfulState
+    :: Members '[State Int, Resource] r
+    => Sem r (Int, Int)
+forgetfulState = do
+  a <- bracket
+         (pure ())
+         (const (put @Int 3))
+         (const (put @Int 2 >> get))
+  (,) <$> pure a <*> get
+
+
+spec :: Spec
+spec = do
+  it "should forget state without GlobalState" $ do
+    let res = run
+            . runResource
+            . evalState @Int 0
+            $ forgetfulState
+    res `shouldBe` (2, 2)
+
+  it "should propagate state written in the cleanup action" $ do
+    let res = run
+            . runGlobalState
+            . runResource
+            $ runStateAsGlobal @Int 0
+            $ forgetfulState
+    res `shouldBe` (2, 3)
+
+  it "should propagate state written in the cleanup action IN IO" $ do
+    res <- (runM . runGlobalStateInIO)
+                 .@ runResourceInIO
+                 $ runStateAsGlobal @Int 0
+                 $ forgetfulState
+    res `shouldBe` (2, 3)
+


### PR DESCRIPTION
This is a possible solution for #84. It's a `State`-like effect that can be deferred until the very end of the day, ensuring it can be run _underneath_ things like `Resource` and `Async`.

The idea is essentially to keep a big map around that you can read from and write to. In IO this is implemented as an `unsafePerformIO`-scoped `IORef` that is atomically updated. Purely, it's just a regular `State` effect.

Elements added to this map have their lifetimes managed via the `allocate` effect, during which you may use `getGlobal` and `putGlobal` on the resulting key. There's a small amount of type-level protection to prevent the keys from escaping their scope, but @Lysxia points out that it's not foolproof.