### PR TITLE
Parenthesize r when it's a cons

### DIFF
--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -112,7 +112,9 @@ type Member e r = MemberNoError e r
 type MemberWithError e r =
   ( MemberNoError e r
 #ifndef NO_ERROR_MESSAGES
-  , WhenStuck (IndexOf r (Found r e)) (AmbiguousSend r e)
+  , WhenStuck
+      (IndexOf r (Found r e))
+      (AmbiguousSend r e)
 #endif
   )
 

--- a/test/TypeErrors.hs
+++ b/test/TypeErrors.hs
@@ -106,13 +106,9 @@ runningTooManyEffects = ()
 -- ...
 -- ... Ambiguous use of effect 'State'
 -- ...
--- ... (Member (State ()) State Int : r) ...
+-- ... (Member (State ()) (State Int : r)) ...
 -- ...
---
--- PROBLEM: There should be parentheses around `State Int : r`
---
--- SOLUTION: Emit parens only when the effect row is of the form `e1 ': ...`
-missingParens'WRONG = ()
+ambiguousSendInConcreteR = ()
 
 
 --------------------------------------------------------------------------------
@@ -141,4 +137,17 @@ missingArgumentToRunResourceInIO = ()
 -- ...
 --
 missingFmap'WRONG = ()
+
+--------------------------------------------------------------------------------
+-- |
+-- >>> :{
+-- foo :: Sem '[State Int, Lift IO] ()
+-- foo = output ()
+-- :}
+-- ...
+-- ... Unhandled effect 'Output ()'
+-- ...
+-- ... add an interpretation for 'Output ()'
+-- ...
+missingEffectInStack'WRONG = ()
 


### PR DESCRIPTION
When emitting messages for ambiguous sends: use `IfStuck` on `r` to
determine if we can compose it. This means `r` is in one of three
states, stuck, cons or nil. We want to wrap it in parentheses iff it's
a cons.

Fixes #74 