### PR TITLE
Don't emit ambiguous effect errors for genuine type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ core-html/
 *.prof
 .ghc.environment.*
 dist-newstyle
+*.hi
+*.o

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 - syb >= 0.7 && < 0.8
 - transformers >= 0.5.2.0 && < 0.6
 - containers >= 0.5 && < 0.7
+- type-errors >= 0.2
 
 library:
   source-dirs: src
@@ -44,6 +45,7 @@ tests:
     - hspec >= 2.6.0 && < 3
     - should-not-typecheck >= 2.1.0 && < 3
     - inspection-testing >= 0.4.2 && < 0.5
+    - doctest >= 0.16.0.1 && < 0.17
 
 default-extensions:
   - DataKinds

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 50ca26f4a5eaf57d215e1a89d157fd1adc6170d4c2233710224ee466693fa127
+-- hash: d8cd2995085b0503fd8a705c9adeb55802c4feebce00cf811bf71474bbceed1f
 
 name:           polysemy-plugin
 version:        0.2.1.1
@@ -45,6 +45,7 @@ library
     , polysemy >=0.1
     , syb >=0.7 && <0.8
     , transformers >=0.5.2.0 && <0.6
+    , type-errors >=0.2
   default-language: Haskell2010
 
 test-suite polysemy-plugin-test
@@ -52,9 +53,11 @@ test-suite polysemy-plugin-test
   main-is: Main.hs
   other-modules:
       BadSpec
+      DoctestSpec
       ExampleSpec
       LegitimateTypeErrorSpec
       PluginSpec
+      TypeErrors
       VDQSpec
       Paths_polysemy_plugin
   hs-source-dirs:
@@ -66,6 +69,7 @@ test-suite polysemy-plugin-test
   build-depends:
       base >=4.9 && <5
     , containers >=0.5 && <0.7
+    , doctest >=0.16.0.1 && <0.17
     , ghc >=8.4.4 && <9
     , ghc-tcplugins-extra >=0.3 && <0.4
     , hspec >=2.6.0 && <3
@@ -75,4 +79,5 @@ test-suite polysemy-plugin-test
     , should-not-typecheck >=2.1.0 && <3
     , syb >=0.7 && <0.8
     , transformers >=0.5.2.0 && <0.6
+    , type-errors >=0.2
   default-language: Haskell2010

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -188,10 +188,9 @@ mkWanted
     -> CtLoc
     -> Type
     -> Type
-    -> TcPluginM ( Maybe ( (OrdType, OrdType)  -- the types we want to unify
-                         , Ct                  -- the constraint
-                         )
-                 )
+    -> TcPluginM (Maybe ( (OrdType, OrdType)  -- the types we want to unify
+                        , Ct                  -- the constraint
+                        ))
 mkWanted solve_ctx loc wanted given =
   whenA (not (mustUnify solve_ctx) || canUnifyRecursive solve_ctx wanted given) $ do
     (ev, _) <- unsafeTcPluginTcM

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -239,6 +239,10 @@ mustUnify :: SolveContext -> Bool
 mustUnify FunctionDef = True
 mustUnify (InterpreterUse b) = b
 
+
+------------------------------------------------------------------------------
+-- | Given a list of 'Ct's, find any that are of the form
+-- @[Irred] Sem r a ~ Something@, and return their @r@s.
 getBogusRs :: PolysemyStuff 'Things -> [Ct] -> [Type]
 getBogusRs stuff wanteds = do
   CIrredCan ct _ <- wanteds
@@ -247,6 +251,9 @@ getBogusRs stuff wanteds = do
       maybeToList (getRIfSem stuff a) ++ maybeToList (getRIfSem stuff b)
     (_, _) -> []
 
+
+------------------------------------------------------------------------------
+-- | Take the @r@ out of @Sem r a@.
 getRIfSem :: PolysemyStuff 'Things -> Type -> Maybe Type
 getRIfSem (semTyCon -> sem) ty =
   case splitTyConApp_maybe ty of
@@ -254,6 +261,9 @@ getRIfSem (semTyCon -> sem) ty =
     _                                   -> Nothing
 
 
+------------------------------------------------------------------------------
+-- | Given a list of bogus @r@s, and the wanted constraints, produce bogus
+-- evidence terms that will prevent @IfStuck (IndexOf r _) _ _@ error messsages.
 solveBogusError :: PolysemyStuff 'Things -> [Type] -> [Ct] -> [(EvTerm, Ct)]
 solveBogusError stuff bogus wanteds = do
   ct@(CIrredCan ce _) <- wanteds

--- a/polysemy-plugin/test/DoctestSpec.hs
+++ b/polysemy-plugin/test/DoctestSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE CPP #-}
+
+module DoctestSpec where
+
+import Test.Hspec
+import Test.DocTest
+
+spec :: Spec
+spec = parallel $ describe "Error messages" $ it "should pass the doctest" $ doctest
+  [ "--fast"
+  , "-fobject-code"
+  , "-XDataKinds"
+  , "-XDeriveFunctor"
+  , "-XFlexibleContexts"
+  , "-XGADTs"
+  , "-XLambdaCase"
+  , "-XPolyKinds"
+  , "-XRankNTypes"
+  , "-XScopedTypeVariables"
+  , "-XStandaloneDeriving"
+  , "-XTypeApplications"
+  , "-XTypeFamilies"
+  , "-XTypeOperators"
+  , "-XUnicodeSyntax"
+
+#if __GLASGOW_HASKELL__ < 806
+  , "-XMonadFailDesugaring"
+  , "-XTypeInType"
+#endif
+
+  , "test/TypeErrors.hs"
+  ]

--- a/polysemy-plugin/test/TypeErrors.hs
+++ b/polysemy-plugin/test/TypeErrors.hs
@@ -5,7 +5,7 @@ module TypeErrors where
 -- $setup
 -- >>> default ()
 -- >>> :set -package polysemy-plugin
--- Loaded package ...
+-- ...
 -- >>> :set -fplugin=Polysemy.Plugin
 -- >>> :m +Polysemy
 -- >>> :m +Polysemy.State

--- a/polysemy-plugin/test/TypeErrors.hs
+++ b/polysemy-plugin/test/TypeErrors.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module TypeErrors where
+
+-- $setup
+-- >>> default ()
+-- >>> :set -package polysemy-plugin
+-- Loaded package ...
+-- >>> :set -fplugin=Polysemy.Plugin
+-- >>> :m +Polysemy
+-- >>> :m +Polysemy.State
+-- >>> :m +Data.Maybe
+
+
+--------------------------------------------------------------------------------
+-- |
+-- >>> :{
+-- existsKV :: Member (State (Maybe Int)) r => Sem r Bool
+-- existsKV = isJust get
+-- :}
+-- ...
+-- ... Couldn't match expected type ...Sem r Bool... with actual type ...Bool...
+-- ...
+-- ... Couldn't match expected type ...Maybe a0...
+-- ... with actual type ...Sem r0 a1...
+-- ...
+missingFmap = ()
+

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -112,6 +112,10 @@ type Member e r = MemberNoError e r
 type MemberWithError e r =
   ( MemberNoError e r
 #ifndef NO_ERROR_MESSAGES
+    -- NOTE: The plugin explicitly pattern matches on
+    -- `WhenStuck (IndexOf r _) _`, so if you change this, make sure to change
+    -- the corresponding implementation in
+    -- Polysemy.Plugin.Fundep.solveBogusError
   , WhenStuck (IndexOf r (Found r e)) (AmbiguousSend r e)
 #endif
   )

--- a/test/TypeErrors.hs
+++ b/test/TypeErrors.hs
@@ -140,11 +140,6 @@ missingArgumentToRunResourceInIO = ()
 -- ... Ambiguous use of effect 'State'
 -- ...
 --
--- PROBLEM: because this doesn't typecheck, `get` has type `Sem r0 a1`, which
--- truly is ambiguous!
---
--- SOLUTION: maybe the plugin can detect the case that we're trying to compare
--- a `Sem r` with something completely unrelated, and then just emit bogus
--- `Find` dictionaries?
-missingFmap'WRONG = ()
+-- NOTE: This is fixed by enabling the plugin!
+missingFmap'PLUGIN = ()
 

--- a/test/TypeErrors.hs
+++ b/test/TypeErrors.hs
@@ -140,5 +140,11 @@ missingArgumentToRunResourceInIO = ()
 -- ... Ambiguous use of effect 'State'
 -- ...
 --
+-- PROBLEM: because this doesn't typecheck, `get` has type `Sem r0 a1`, which
+-- truly is ambiguous!
+--
+-- SOLUTION: maybe the plugin can detect the case that we're trying to compare
+-- a `Sem r` with something completely unrelated, and then just emit bogus
+-- `Find` dictionaries?
 missingFmap'WRONG = ()
 


### PR DESCRIPTION
This PR changes the plugin so it will notice an insoluble constraint of the form `Sem r a ~ Foo`, and mark that `r` takes part in a genuine type error. The plugin will then provide a bogus evidence term for `IfStuck (IndexOf r _) _ _`, which prevents the `AmbiguousSend` error message from firing.

Fixes #136 and #108 