### PR TITLE
Rename Yo ==> Weaving

### DIFF
--- a/src/Polysemy/Error.hs
+++ b/src/Polysemy/Error.hs
@@ -77,8 +77,8 @@ runError (Sem m) = Sem $ \k -> E.runExceptT $ m $ \u ->
             (either (pure . Left) runError)
             hush
             x
-    Right (Yo (Throw e) _ _ _ _) -> E.throwE e
-    Right (Yo (Catch try handle) s d y _) ->
+    Right (Weaving (Throw e) _ _ _ _) -> E.throwE e
+    Right (Weaving (Catch try handle) s d y _) ->
       E.ExceptT $ usingSem k $ do
         ma <- runError $ d $ try <$ s
         case ma of

--- a/src/Polysemy/IO.hs
+++ b/src/Polysemy/IO.hs
@@ -68,6 +68,6 @@ runEmbedded run_m (Sem m) = withLowerToIO $ \lower _ ->
               . liftSem
               $ hoist (runEmbedded run_m) x
 
-      Right (Yo (Lift wd) s _ y _) ->
+      Right (Weaving (Lift wd) s _ y _) ->
         fmap y $ fmap (<$ s) wd
 

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -327,7 +327,7 @@ run (Sem m) = runIdentity $ m absurdU
 runM :: Monad m => Sem '[Lift m] a -> m a
 runM (Sem m) = m $ \z ->
   case extract z of
-    Yo e s _ f _ -> do
+    Weaving e s _ f _ -> do
       a <- unLift e
       pure $ f $ a <$ s
 {-# INLINE runM #-}

--- a/src/Polysemy/Internal/Combinators.hs
+++ b/src/Polysemy/Internal/Combinators.hs
@@ -73,7 +73,7 @@ interpretH
 interpretH f (Sem m) = m $ \u ->
   case decomp u of
     Left  x -> liftSem $ hoist (interpretH f) x
-    Right (Yo e s d y v) -> do
+    Right (Weaving e s d y v) -> do
       a <- runTactics s d v $ f e
       pure $ y a
 {-# INLINE interpretH #-}
@@ -96,7 +96,7 @@ interpretInStateT f s (Sem m) = Sem $ \k ->
                     (uncurry $ interpretInStateT f)
                     (Just . snd)
             $ x
-        Right (Yo e z _ y _) ->
+        Right (Weaving e z _ y _) ->
           fmap (y . (<$ z)) $ S.mapStateT (usingSem k) $ f e
 {-# INLINE interpretInStateT #-}
 
@@ -118,7 +118,7 @@ interpretInLazyStateT f s (Sem m) = Sem $ \k ->
                     (uncurry $ interpretInLazyStateT f)
                     (Just . snd)
             $ x
-        Right (Yo e z _ y _) ->
+        Right (Weaving e z _ y _) ->
           fmap (y . (<$ z)) $ LS.mapStateT (usingSem k) $ f e
 {-# INLINE interpretInLazyStateT #-}
 
@@ -158,7 +158,7 @@ reinterpretH
 reinterpretH f (Sem m) = Sem $ \k -> m $ \u ->
   case decompCoerce u of
     Left x  -> k $ hoist (reinterpretH f) $ x
-    Right (Yo e s d y v) -> do
+    Right (Weaving e s d y v) -> do
       a <- usingSem k $ runTactics s (raiseUnder . d) v $ f e
       pure $ y a
 {-# INLINE[3] reinterpretH #-}
@@ -195,7 +195,7 @@ reinterpret2H
 reinterpret2H f (Sem m) = Sem $ \k -> m $ \u ->
   case decompCoerce u of
     Left x  -> k $ weaken $ hoist (reinterpret2H f) $ x
-    Right (Yo e s d y v) -> do
+    Right (Weaving e s d y v) -> do
       a <- usingSem k $ runTactics s (raiseUnder2 . d) v $ f e
       pure $ y a
 {-# INLINE[3] reinterpret2H #-}
@@ -227,7 +227,7 @@ reinterpret3H
 reinterpret3H f (Sem m) = Sem $ \k -> m $ \u ->
   case decompCoerce u of
     Left x  -> k . weaken . weaken . hoist (reinterpret3H f) $ x
-    Right (Yo e s d y v) -> do
+    Right (Weaving e s d y v) -> do
       a <- usingSem k $ runTactics s (raiseUnder3 . d) v $ f e
       pure $ y a
 {-# INLINE[3] reinterpret3H #-}
@@ -278,7 +278,7 @@ interceptH
     -> Sem r a
 interceptH f (Sem m) = Sem $ \k -> m $ \u ->
   case prj u of
-    Just (Yo e s d y v) ->
+    Just (Weaving e s d y v) ->
       usingSem k $ fmap y $ runTactics s (raise . d) v $ f e
     Nothing -> k $ hoist (interceptH f) u
 {-# INLINE interceptH #-}

--- a/src/Polysemy/Internal/Tactics.hs
+++ b/src/Polysemy/Internal/Tactics.hs
@@ -192,11 +192,11 @@ runTactics
 runTactics s d v (Sem m) = m $ \u ->
   case decomp u of
     Left x -> liftSem $ hoist (runTactics s d v) x
-    Right (Yo GetInitialState s' _ y _) ->
+    Right (Weaving GetInitialState s' _ y _) ->
       pure $ y $ s <$ s'
-    Right (Yo (HoistInterpretation na) s' _ y _) -> do
+    Right (Weaving (HoistInterpretation na) s' _ y _) -> do
       pure $ y $ (d . fmap na) <$ s'
-    Right (Yo GetInspector s' _ y _) -> do
+    Right (Weaving GetInspector s' _ y _) -> do
       pure $ y $ Inspector v <$ s'
 {-# INLINE runTactics #-}
 

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -90,7 +90,6 @@ data Weaving e m a where
          -- 'Polysemy.Error.Error' might have 'Polysemy.Error.throw'n.)
        }
     -> Weaving e n b
-       -- ^ There is an invariant that @n ~ Sem r@.
 
 instance Functor (Weaving e m) where
   fmap f (Weaving e s d f' v) = Weaving e s d (f . f') v

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances       #-}
 {-# LANGUAGE FunctionalDependencies  #-}
 {-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE PatternSynonyms         #-}
 {-# LANGUAGE StrictData              #-}
 {-# LANGUAGE TypeFamilies            #-}
 {-# LANGUAGE UndecidableInstances    #-}
@@ -13,7 +14,7 @@
 
 module Polysemy.Internal.Union
   ( Union (..)
-  , Yo (..)
+  , Weaving (..)
   , Member
   , MemberWithError
   , weave
@@ -55,7 +56,7 @@ data Union (r :: EffectRow) (m :: Type -> Type) a where
          SNat n
          -- The effect to wrap. The functions 'prj' and 'decomp' can help
          -- retrieve this value later.
-      -> Yo (IndexOf r n) m a
+      -> Weaving (IndexOf r n) m a
       -> Union r m a
 
 instance Functor (Union r m) where
@@ -63,17 +64,37 @@ instance Functor (Union r m) where
   {-# INLINE fmap #-}
 
 
-data Yo e m a where
-  Yo :: Functor f
-     => e m a
-     -> f ()
-     -> (forall x. f (m x) -> n (f x))
-     -> (f a -> b)
-     -> (forall x. f x -> Maybe x)
-     -> Yo e n b
+data Weaving e m a where
+  Weaving
+    :: Functor f
+    =>   { weaveEffect :: e m a
+         -- ^ The original effect GADT originally lifted via
+         -- 'Polysemy.Internal.send'. There is an invariant that @m ~ Sem r0@,
+         -- where @r0@ is the effect row that was in scope when this 'Weaving'
+         -- was originally created.
+       , weaveState :: f ()
+         -- ^ A piece of state that other effects' interpreters have already
+         -- woven through this 'Weaving'. @f@ is a 'Functor', so you can always
+         -- 'fmap' into this thing.
+       , weaveDistrib :: forall x. f (m x) -> n (f x)
+         -- ^ Distribute @f@ by transforming @m@ into @n@. We have invariants
+         -- on @m@ and @n@, which means in actuality this function looks like
+         -- @f ('Polysemy.Sem' (Some ': Effects ': r) x) -> 'Polysemy.Sem' r (f
+         -- x)@.
+       , weaveResult :: f a -> b
+         -- ^ Even though @f a@ is the moral resulting type of 'Weaving', we
+         -- can't expose that fact; such a thing would prevent 'Polysemy.Sem'
+         -- from being a 'Monad'.
+       , weaveInspect :: forall x. f x -> Maybe x
+         -- ^ A function for attempting to see inside an @f@. This is no
+         -- guarantees that such a thing will succeed (for example,
+         -- 'Polysemy.Error.Error' might have 'Polysemy.Error.throw'n.)
+       }
+    -> Weaving e n b
+       -- ^ There is an invariant that @n ~ Sem r@.
 
-instance Functor (Yo e m) where
-  fmap f (Yo e s d f' v) = Yo e s d (f . f') v
+instance Functor (Weaving e m) where
+  fmap f (Weaving e s d f' v) = Weaving e s d (f . f') v
   {-# INLINE fmap #-}
 
 
@@ -85,8 +106,8 @@ weave
     -> (∀ x. s x -> Maybe x)
     -> Union r m a
     -> Union r n (s a)
-weave s' d v' (Union w (Yo e s nt f v)) = Union w $
-    Yo e (Compose $ s <$ s')
+weave s' d v' (Union w (Weaving e s nt f v)) = Union w $
+    Weaving e (Compose $ s <$ s')
          (fmap Compose . d . fmap nt . getCompose)
          (fmap f . getCompose)
          (v <=< v' . getCompose)
@@ -100,7 +121,7 @@ hoist
     => (∀ x. m x -> n x)
     -> Union r m a
     -> Union r n a
-hoist f' (Union w (Yo e s nt f v)) = Union w $ Yo e s (f' . nt) f v
+hoist f' (Union w (Weaving e s nt f v)) = Union w $ Weaving e s (f' . nt) f v
 {-# INLINE hoist #-}
 
 
@@ -178,7 +199,7 @@ instance ( Find z t
 ------------------------------------------------------------------------------
 -- | Decompose a 'Union'. Either this union contains an effect @e@---the head
 -- of the @r@ list---or it doesn't.
-decomp :: Union (e ': r) m a -> Either (Union r m a) (Yo e m a)
+decomp :: Union (e ': r) m a -> Either (Union r m a) (Weaving e m a)
 decomp (Union p a) =
   case p of
     SZ   -> Right a
@@ -188,7 +209,7 @@ decomp (Union p a) =
 
 ------------------------------------------------------------------------------
 -- | Retrieve the last effect in a 'Union'.
-extract :: Union '[e] m a -> Yo e m a
+extract :: Union '[e] m a -> Weaving e m a
 extract (Union SZ a) = a
 extract _ = error "impossible"
 {-# INLINE extract #-}
@@ -212,10 +233,10 @@ weaken (Union n a) = Union (SS n) a
 -- | Lift an effect @e@ into a 'Union' capable of holding it.
 inj :: forall r e a m. (Functor m , Member e r) => e m a -> Union r m a
 inj e = Union (finder @_ @r @e) $
-  Yo e (Identity ())
-       (fmap Identity . runIdentity)
-       runIdentity
-       (Just . runIdentity)
+  Weaving e (Identity ())
+            (fmap Identity . runIdentity)
+            runIdentity
+            (Just . runIdentity)
 {-# INLINE inj #-}
 
 
@@ -225,12 +246,11 @@ prj :: forall e r a m
      . ( Member e r
        )
     => Union r m a
-    -> Maybe (Yo e m a)
+    -> Maybe (Weaving e m a)
 prj (Union sn a) =
-  let sm = finder @_ @r @e
-   in case testEquality sn sm of
-        Nothing -> Nothing
-        Just Refl -> Just a
+  case testEquality sn (finder @_ @r @e) of
+    Nothing -> Nothing
+    Just Refl -> Just a
 {-# INLINE prj #-}
 
 
@@ -239,7 +259,7 @@ prj (Union sn a) =
 -- 'Polysemy.Interpretation.reinterpret' function.
 decompCoerce
     :: Union (e ': r) m a
-    -> Either (Union (f ': r) m a) (Yo e m a)
+    -> Either (Union (f ': r) m a) (Weaving e m a)
 decompCoerce (Union p a) =
   case p of
     SZ -> Right a
@@ -263,3 +283,4 @@ instance {-# OVERLAPPABLE #-} (LastMember end r, MemberNoError end (eff ': r))
 
 instance LastMember end '[end] where
   decompLast = Right
+

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances       #-}
 {-# LANGUAGE FunctionalDependencies  #-}
 {-# LANGUAGE MultiParamTypeClasses   #-}
-{-# LANGUAGE PatternSynonyms         #-}
 {-# LANGUAGE StrictData              #-}
 {-# LANGUAGE TypeFamilies            #-}
 {-# LANGUAGE UndecidableInstances    #-}

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -107,9 +107,9 @@ weave
     -> Union r n (s a)
 weave s' d v' (Union w (Weaving e s nt f v)) = Union w $
     Weaving e (Compose $ s <$ s')
-         (fmap Compose . d . fmap nt . getCompose)
-         (fmap f . getCompose)
-         (v <=< v' . getCompose)
+              (fmap Compose . d . fmap nt . getCompose)
+              (fmap f . getCompose)
+              (v <=< v' . getCompose)
 {-# INLINE weave #-}
 
 

--- a/src/Polysemy/NonDet.hs
+++ b/src/Polysemy/NonDet.hs
@@ -64,8 +64,8 @@ runNonDet (Sem m) = Sem $ \k -> runNonDetC $ m $ \u ->
                      listToMaybe
                      x
       foldr cons nil z
-    Right (Yo Empty _ _ _ _) -> empty
-    Right (Yo (Choose ek) s _ y _) -> do
+    Right (Weaving Empty _ _ _ _) -> empty
+    Right (Weaving (Choose ek) s _ y _) -> do
       z <- pure (ek False) <|> pure (ek True)
       pure $ y $ z <$ s
 

--- a/src/Polysemy/State.hs
+++ b/src/Polysemy/State.hs
@@ -106,8 +106,8 @@ hoistStateIntoStateT (Sem m) = m $ \u ->
                                   $ S.runStateT m' s')
                       (Just . snd)
               $ hoist hoistStateIntoStateT x
-    Right (Yo Get z _ y _)     -> fmap (y . (<$ z)) $ S.get
-    Right (Yo (Put s) z _ y _) -> fmap (y . (<$ z)) $ S.put s
+    Right (Weaving Get z _ y _)     -> fmap (y . (<$ z)) $ S.get
+    Right (Weaving (Put s) z _ y _) -> fmap (y . (<$ z)) $ S.put s
 {-# INLINE hoistStateIntoStateT #-}
 
 

--- a/test/FusionSpec.hs
+++ b/test/FusionSpec.hs
@@ -57,11 +57,13 @@ spec = parallel $ do
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'Sem)
       shouldSucceed $(inspectTest $ 'tryIt `doesNotUse` 'Sem)
 
+#if __GLASGOW_HASKELL__ >= 806
     it "who needs Weaving even?" $ do
-      shouldSucceed $(inspectTest $ 'countDown `doesNotUse` 'Weaving)
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'Weaving)
+      shouldSucceed $(inspectTest $ 'countDown `doesNotUse` 'Weaving)
 #if __GLASGOW_HASKELL__ >= 810
       shouldSucceed $(inspectTest $ 'tryIt `doesNotUse` 'Weaving)
+#endif
 #endif
 
 

--- a/test/FusionSpec.hs
+++ b/test/FusionSpec.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -O2           #-}
+
+{-# OPTIONS_GHC -O2 #-}
+{-# OPTIONS_GHC -dsuppress-idinfo -dsuppress-coercions #-}
 
 
 #if __GLASGOW_HASKELL__ < 804
@@ -50,10 +52,17 @@ spec = parallel $ do
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'reinterpret)
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'hoist)
 
-    it "who needs Semantic even?" $ do
+    it "who needs Sem even?" $ do
       shouldSucceed $(inspectTest $ 'countDown `doesNotUse` 'Sem)
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'Sem)
       shouldSucceed $(inspectTest $ 'tryIt `doesNotUse` 'Sem)
+
+    it "who needs Weaving even?" $ do
+      shouldSucceed $(inspectTest $ 'countDown `doesNotUse` 'Weaving)
+      shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'Weaving)
+#if __GLASGOW_HASKELL__ >= 810
+      shouldSucceed $(inspectTest $ 'tryIt `doesNotUse` 'Weaving)
+#endif
 
 
 go :: Sem '[State Int] Int


### PR DESCRIPTION
The name `Yo` is objectively terrible. I changed it, and added some documentation.

Fixes #159 