### PR TITLE
Don't use Loopbreaker until GHC 8.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
  - cabal v2-update
  - cabal v2-build
  - cabal v2-test --enable-test
- - cabal new-haddock 2>&1 >/dev/null | ! grep 'Failed to build documentation'
+ - "! cabal new-haddock 2>&1 >/dev/null | grep 'Failed to build documentation'; echo $?"
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
  - cabal v2-update
  - cabal v2-build
  - cabal v2-test --enable-test
- - "! cabal new-haddock 2>&1 >/dev/null | grep 'Failed to build documentation'; echo $?"
+ - "! cabal new-haddock 2>&1 >/dev/null | grep 'Failed to build documentation'"
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
  - cabal v2-update
  - cabal v2-build
  - cabal v2-test --enable-test
+   # This weird bash stuff is a workaround for haskell/cabal#5977
  - "! cabal new-haddock 2>&1 >/dev/null | grep 'Failed to build documentation'"
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
  - cabal v2-update
  - cabal v2-build
  - cabal v2-test --enable-test
- - cabal new-haddock
+ - cabal new-haddock 2>&1 >/dev/null | ! grep 'Failed to build documentation'
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 

--- a/package.yaml
+++ b/package.yaml
@@ -49,7 +49,7 @@ when:
       - MonadFailDesugaring
       - TypeInType
 
-  - condition: impl(ghc >= 8.6)
+  - condition: impl(ghc >= 8.7)
     dependencies:
       - loopbreaker >= 0.1 && < 0.2
 
@@ -83,7 +83,7 @@ library:
     # We use this plugin to get to more agressive inlining without need for
     # explicit "loopbreakers" in function definitions all over ther codebase
     # --- sadly it can only work on newer versions of GHC currently
-    - condition: impl(ghc >= 8.6)
+    - condition: impl(ghc >= 8.7)
       ghc-options:
         - -fplugin=Loopbreaker
 

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fd80d4218e2d56a0c2af9f4bd89fc79c0ebce4fe968415430a6009ee91205586
+-- hash: 81ab3886c51d2b5a58bab1b06a498983d76778f000144d42e36ecc84a0cfb3bb
 
 name:           polysemy
 version:        0.6.0.0
@@ -85,7 +85,7 @@ library
     , unagi-chan >=0.4.0.0 && <0.5
   if impl(ghc < 8.6)
     default-extensions: MonadFailDesugaring TypeInType
-  if impl(ghc >= 8.6)
+  if impl(ghc >= 8.7)
     build-depends:
         loopbreaker >=0.1 && <0.2
   if flag(dump-core)
@@ -95,7 +95,7 @@ library
   if impl(ghc < 8.2.2)
     build-depends:
         unsupported-ghc-version >1 && <1
-  if impl(ghc >= 8.6)
+  if impl(ghc >= 8.7)
     ghc-options: -fplugin=Loopbreaker
   if flag(error-messages)
     cpp-options: -DCABAL_SERIOUSLY_CMON_MATE
@@ -143,7 +143,7 @@ test-suite polysemy-test
     , unagi-chan >=0.4.0.0 && <0.5
   if impl(ghc < 8.6)
     default-extensions: MonadFailDesugaring TypeInType
-  if impl(ghc >= 8.6)
+  if impl(ghc >= 8.7)
     build-depends:
         loopbreaker >=0.1 && <0.2
   default-language: Haskell2010
@@ -175,7 +175,7 @@ benchmark polysemy-bench
     , unagi-chan >=0.4.0.0 && <0.5
   if impl(ghc < 8.6)
     default-extensions: MonadFailDesugaring TypeInType
-  if impl(ghc >= 8.6)
+  if impl(ghc >= 8.7)
     build-depends:
         loopbreaker >=0.1 && <0.2
   default-language: Haskell2010

--- a/test/FusionSpec.hs
+++ b/test/FusionSpec.hs
@@ -35,7 +35,7 @@ shouldSucceed r = r `shouldSatisfy` isSuccess
 spec :: Spec
 spec = parallel $ do
   describe "fusion" $ do
-#if __GLASGOW_HASKELL__ >= 806
+#if __GLASGOW_HASKELL__ >= 807
     -- TODO: Investigate why this test fails mysteriously on GHC < 8.6
     it "Union proofs should simplify" $ do
       shouldSucceed $(inspectTest $ 'countDown `hasNoType` ''SNat)
@@ -57,7 +57,7 @@ spec = parallel $ do
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'Sem)
       shouldSucceed $(inspectTest $ 'tryIt `doesNotUse` 'Sem)
 
-#if __GLASGOW_HASKELL__ >= 806
+#if __GLASGOW_HASKELL__ >= 807
     it "who needs Weaving even?" $ do
       shouldSucceed $(inspectTest $ 'jank `doesNotUse` 'Weaving)
       shouldSucceed $(inspectTest $ 'countDown `doesNotUse` 'Weaving)


### PR DESCRIPTION
Turns out haddocks have been broken forever, but because of https://github.com/haskell/cabal/issues/5977 we never noticed. This PR fixes CI so it breaks (see 6f915b6), and then fixes it by changing the GHC versions under which we're allowed to use loopbreaker. Fixes #160 