### PR TITLE
Make NonDet Higher-Order

### DIFF
--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -211,10 +211,7 @@ instance Monad (Sem f) where
 instance (Member NonDet r) => Alternative (Sem r) where
   empty = send Empty
   {-# INLINE empty #-}
-  a <|> b = do
-    send (Choose id) >>= \case
-      False -> a
-      True  -> b
+  a <|> b = send (Choose a b)
   {-# INLINE (<|>) #-}
 
 -- | @since 0.2.1.0

--- a/src/Polysemy/Internal/NonDet.hs
+++ b/src/Polysemy/Internal/NonDet.hs
@@ -6,12 +6,10 @@
 
 module Polysemy.Internal.NonDet where
 
-import Data.Kind
-
 
 ------------------------------------------------------------------------------
 -- | An effect corresponding to the 'Control.Applicative.Alternative' typeclass.
-data NonDet (m :: Type -> Type) a
+data NonDet m a
   = Empty
-  | Choose (Bool -> a)
+  | Choose (m a) (m a)
 

--- a/src/Polysemy/NonDet.hs
+++ b/src/Polysemy/NonDet.hs
@@ -80,7 +80,7 @@ runNonDetInC = usingSem $ \u ->
 --
 -- Unlike 'runNonDet', uses of '<|>' will not execute any "local" effects of the
 -- second branch at all if the first option succeeds.
-
+--
 -- I.e. any effects whose interpreters are run before 'runNonDetMaybe' will
 -- be skipped. Effects whose interpreters are run after 'runNonDetMaybe'
 -- will /not/ be skipped.

--- a/src/Polysemy/NonDet.hs
+++ b/src/Polysemy/NonDet.hs
@@ -78,12 +78,8 @@ runNonDetInC = usingSem $ \u ->
 ------------------------------------------------------------------------------
 -- | Run a 'NonDet' effect in terms of an underlying 'Maybe'
 --
--- Unlike 'runNonDet', uses of '<|>' will not execute any "local" effects of the
+-- Unlike 'runNonDet', uses of '<|>' will not execute the
 -- second branch at all if the first option succeeds.
---
--- I.e. any effects whose interpreters are run before 'runNonDetMaybe' will
--- be skipped. Effects whose interpreters are run after 'runNonDetMaybe'
--- will /not/ be skipped.
 runNonDetMaybe :: Sem (NonDet ': r) a -> Sem r (Maybe a)
 runNonDetMaybe (Sem sem) = Sem $ \k -> runMaybeT $ sem $ \u ->
   case decomp u of

--- a/test/AlternativeSpec.hs
+++ b/test/AlternativeSpec.hs
@@ -40,14 +40,14 @@ spec = parallel $ do
       runAlt (semFail $ Just False) `shouldBe` [False]
 
   describe "runNonDetMaybe" $ do
-    it "should skip (only) local effects if the first branch succeeds" $ do
-      (run . runNonDet . runTraceAsList) failtrace
+    it "should skip second branch if the first branch succeeds" $ do
+      (run . runNonDetMaybe . runTraceAsList) failtrace
         `shouldBe` Just ([], ())
-      (run . runTraceAsList . runNonDet) failtrace
-        `shouldBe` (["trace"], Just ())
+      (run . runTraceAsList . runNonDetMaybe) failtrace
+        `shouldBe` ([], Just ())
 
     it "should respect local/global state semantics" $ do
-      (run . runNonDet . runTraceAsList) failtrace'
+      (run . runNonDetMaybe . runTraceAsList) failtrace'
         `shouldBe` Just (["salabim"], ())
-      (run . runTraceAsList . runNonDet) failtrace'
+      (run . runTraceAsList . runNonDetMaybe) failtrace'
         `shouldBe` (["sim", "salabim"], Just ())

--- a/test/AlternativeSpec.hs
+++ b/test/AlternativeSpec.hs
@@ -4,16 +4,23 @@ import Polysemy
 import Polysemy.NonDet
 import Test.Hspec
 import Control.Applicative
+import Polysemy.Trace
 
 semFail :: Member NonDet r => Maybe Bool -> Sem r Bool
 semFail mb = do
   Just b <- pure mb
   pure b
 
-
 runAlt :: Alternative f => Sem '[NonDet] a -> f a
 runAlt = run . runNonDet
 
+failtrace :: (Member NonDet r, Member Trace r)
+          => Sem r ()
+failtrace = pure () <|> trace "trace"
+
+failtrace' :: (Member NonDet r, Member Trace r)
+           => Sem r ()
+failtrace' = trace "sim" *> empty <|> trace "salabim"
 
 spec :: Spec
 spec = parallel $ do
@@ -32,3 +39,15 @@ spec = parallel $ do
       runAlt (semFail $ Just True) `shouldBe` Just True
       runAlt (semFail $ Just False) `shouldBe` [False]
 
+  describe "runNonDetMaybe" $ do
+    it "should skip (only) local effects if the second branch succeeds" $ do
+      (run . runNonDet . runTraceAsList) failtrace
+        `shouldBe` Just ([], ())
+      (run . runTraceAsList . runNonDet) failtrace
+        `shouldBe` (["trace"], Just ())
+
+    it "should respect local/global state semantics" $ do
+      (run . runNonDet . runTraceAsList) failtrace'
+        `shouldBe` Just (["salabim"], ())
+      (run . runTraceAsList . runNonDet) failtrace'
+        `shouldBe` (["sim", "salabim"], Just ())

--- a/test/AlternativeSpec.hs
+++ b/test/AlternativeSpec.hs
@@ -40,7 +40,7 @@ spec = parallel $ do
       runAlt (semFail $ Just False) `shouldBe` [False]
 
   describe "runNonDetMaybe" $ do
-    it "should skip (only) local effects if the second branch succeeds" $ do
+    it "should skip (only) local effects if the first branch succeeds" $ do
       (run . runNonDet . runTraceAsList) failtrace
         `shouldBe` Just ([], ())
       (run . runTraceAsList . runNonDet) failtrace


### PR DESCRIPTION
`Alternative` is typically used for simple exception handling a la "try-otherwise". However, `NonDet` is too weak in its current form to write interpreters for it that actually skip effects of the second branch. The solution to this is to make `NonDet` higher-order.

I also chose to represent `Choose` through embedding the two branches directly, as `Bool -> m a` is isomorphic to `(m a, m a)`, and the latter formulation is _probably_ more efficient.

This does not actually break anything - you can still write `runNonDet` with the same semantics as before (although my implementation could possibly be less efficient).
But now you can also write interpreters like `runNonDetMaybe`, which skips local effects (i.e. effects whose interpreters have already been run) of the second branch if the first branch succeeds.

Over at `polysemy-zoo`, this also allows me to write the following:
```haskell
runNonDetFinal :: (Member (Final m) r, Monad m, Alternative m)
               => Sem (NonDet ': r) a
               -> Sem r a
```
which interprets the uses of `<|>` and `empty` in terms of a final `Alternative`.
