### PR TITLE
Document change in semantics based on order of interpreters

### DIFF
--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -100,8 +100,7 @@ import Polysemy.Internal.Union
 -- main = example
 --     'Data.Function.&' 'Polysemy.Error.runError'
 --     'Data.Function.&' fmap (either id id)
---     'Data.Function.&' 'Polysemy.State.runState' ""
---     'Data.Function.&' fmap snd
+--     'Data.Function.&' 'Polysemy.State.evalState' ""
 --     'Data.Function.&' 'runM'
 --     'Data.Function.&' (print =<<)
 -- @
@@ -114,8 +113,7 @@ import Polysemy.Internal.Union
 -- @
 -- main :: IO ()
 -- main = example
---     'Data.Function.&' 'Polysemy.State.runState' ""
---     'Data.Function.&' fmap snd
+--     'Data.Function.&' 'Polysemy.State.evalState' ""
 --     'Data.Function.&' 'Polysemy.Error.runError'
 --     'Data.Function.&' fmap (either id id)
 --     'Data.Function.&' 'runM'

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -121,8 +121,8 @@ import Polysemy.Internal.Union
 -- :}
 -- "start-catch"
 --
--- Good rule of thumb is to handle effect which should have "global" behaviour
--- over other effect later in chain.
+-- A good rule of thumb is to handle effects which should have \"global\"
+-- behaviour over other effects later in the chain.
 --
 -- After all of your effects are handled, you'll be left with either
 -- a @'Sem' '[] a@ or a @'Sem' '[ 'Embed' m ] a@ value, which can be

--- a/test/DoctestSpec.hs
+++ b/test/DoctestSpec.hs
@@ -23,6 +23,8 @@ spec = parallel $ describe "Error messages" $ it "should pass the doctest" $ doc
   , "-XTypeOperators"
   , "-XUnicodeSyntax"
 
+  , "-package type-errors"
+
 #if __GLASGOW_HASKELL__ < 806
   , "-XMonadFailDesugaring"
   , "-XTypeInType"
@@ -32,6 +34,7 @@ spec = parallel $ describe "Error messages" $ it "should pass the doctest" $ doc
 
   -- Modules that are explicitly imported for this test must be listed here
   , "src/Polysemy.hs"
+  , "src/Polysemy/Error.hs"
   , "src/Polysemy/Output.hs"
   , "src/Polysemy/Reader.hs"
   , "src/Polysemy/Resource.hs"


### PR DESCRIPTION
Fixes #127.

Does `resourceToIO` need any more documentation?
