### PR TITLE
Simplified Forklift machinery, remove `LastMember`

### DIFF
--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -3,7 +3,6 @@ module Polysemy
     Sem ()
   , Member
   , Members
-  , LastMember
 
   -- * Running Sem
   , run
@@ -125,5 +124,4 @@ import Polysemy.Internal.Forklift
 import Polysemy.Internal.Kind
 import Polysemy.Internal.TH.Effect
 import Polysemy.Internal.Tactics
-import Polysemy.Internal.Union
 

--- a/src/Polysemy/Async.hs
+++ b/src/Polysemy/Async.hs
@@ -41,7 +41,7 @@ makeSem ''Async
 --
 -- @since 1.0.0.0
 asyncToIO
-    :: LastMember (Embed IO) r
+    :: Member (Embed IO) r
     => Sem (Async ': r) a
     -> Sem r a
 asyncToIO m = withLowerToIO $ \lower _ -> lower $

--- a/src/Polysemy/IO.hs
+++ b/src/Polysemy/IO.hs
@@ -55,7 +55,7 @@ embedToMonadIO = runEmbedded $ liftIO @m
 -- @since 1.0.0.0
 lowerEmbedded
     :: ( MonadIO m
-       , LastMember (Embed IO) r
+       , Member (Embed IO) r
        )
     => (forall x. m x -> IO x)  -- ^ The means of running this monad.
     -> Sem (Embed m ': r) a

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -30,10 +30,8 @@ module Polysemy.Internal.Union
   -- * Witnesses
   , SNat (..)
   , Nat (..)
-  , LastMember (..)
   ) where
 
-import Data.Bifunctor
 import Control.Monad
 import Data.Functor.Compose
 import Data.Functor.Identity
@@ -263,22 +261,3 @@ decompCoerce (Union p a) =
     SZ -> Right a
     SS n -> Left (Union (SS n) a)
 {-# INLINE decompCoerce #-}
-
-
-------------------------------------------------------------------------------
--- | A proof that @end@ is the last effect in the row.
---
--- @since 0.5.0.0
-class MemberNoError end r => LastMember end r | r -> end where
-  decompLast
-      :: Union r m a
-      -> Either (Union r m a) (Union '[end] m a)
-
-instance {-# OVERLAPPABLE #-} (LastMember end r, MemberNoError end (eff ': r))
-      => LastMember end (eff ': r) where
-  decompLast (Union SZ u)     = Left $ Union SZ u
-  decompLast (Union (SS n) u) = first weaken $ decompLast $ Union n u
-
-instance LastMember end '[end] where
-  decompLast = Right
-

--- a/src/Polysemy/Resource.hs
+++ b/src/Polysemy/Resource.hs
@@ -166,7 +166,7 @@ runResource = interpretH $ \case
 -- @since 1.0.0.0
 resourceToIO
     :: forall r a
-     . LastMember (Embed IO) r
+     . Member (Embed IO) r
     => Sem (Resource ': r) a
     -> Sem r a
 resourceToIO = interpretH $ \case


### PR DESCRIPTION
This simplifies the `Forklift` machinery, and removes the need for `LastMember`.

Note that this is a breaking change, which is a bit of a shame seeing how we just released v1...

This closes #183 