### PR TITLE
Improve semantics of Fixpoint

### DIFF
--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f543f8ca2c4f661f0b6702fb6ec6d7db075660d19bf550e50a04e64c56826913
+-- hash: 8270550ff4f07c1da7b354658c67baeb52909c17c4627b20cc55779789133beb
 
 name:           polysemy
 version:        1.0.0.0
@@ -113,6 +113,7 @@ test-suite polysemy-test
       AsyncSpec
       BracketSpec
       DoctestSpec
+      FixpointSpec
       FusionSpec
       HigherOrderSpec
       InspectorSpec

--- a/src/Polysemy/Fixpoint.hs
+++ b/src/Polysemy/Fixpoint.hs
@@ -27,13 +27,13 @@ import Polysemy.Internal.Fixpoint
 -- @
 -- bad :: (Int, Either () Int)
 -- bad =
---    run
---  . runFixpoint run
---  . runLazyState @Int 1
---  . runError
+--    'run'
+--  . 'runFixpoint' 'run'
+--  . 'Polysemy.State.runLazyState' @Int 1
+--  . 'Polysemy.Error.runError'
 --  $ mdo
---   put a
---   a <- throw ()
+--   'Polysemy.State.put' a
+--   a <- 'Polysemy.Error.throw' ()
 --   return a
 -- @
 --

--- a/src/Polysemy/Fixpoint.hs
+++ b/src/Polysemy/Fixpoint.hs
@@ -12,21 +12,46 @@ import Control.Monad.Fix
 import Polysemy
 import Polysemy.Internal.Fixpoint
 
-
 ------------------------------------------------------------------------------
 -- | Run a 'Fixpoint' effect purely.
+--
+-- __Note__: 'runFixpoint' operates under the assumption that any effectful
+-- state which can't be inspected using 'Polysemy.Inspector' can't contain any
+-- values. This is true for all interpreters featured in this package,
+-- and is presumably always true for any properly implemented interpreter.
+--
+-- If 'runFixpoint' throws an exception for you, then you're likely using
+-- some interpreter outside of this package that uses
+-- 'Polysemy.Internal.Union.weave' improperly.
+-- If this cannot possibly be the case, open an issue over at the
+-- GitHub repository.
 runFixpoint
     :: (∀ x. Sem r x -> x)
     -> Sem (Fixpoint ': r) a
     -> Sem r a
 runFixpoint lower = interpretH $ \case
   Fixpoint mf -> do
-    c <- bindT mf
-    pure $ fix $ lower . runFixpoint lower . c
-
+    c   <- bindT mf
+    s   <- getInitialStateT
+    ins <- getInspectorT
+    pure $ fix $ \fa ->
+      lower . runFixpoint lower . c $
+        maybe (bomb "runFixpoint") id (inspect ins fa) <$ s
+{-# INLINE runFixpoint #-}
 
 ------------------------------------------------------------------------------
 -- | Run a 'Fixpoint' effect in terms of an underlying 'MonadFix' instance.
+--
+-- __Note__: 'runFixpointM' operates under the assumption that any effectful
+-- state which can't be inspected using 'Polysemy.Inspector' can't contain any
+-- values. This is true for all interpreters featured in this package,
+-- and is presumably always true for any properly implemented interpreter.
+--
+-- If 'runFixpointM' throws an exception for you, then you're likely using
+-- some interpreter outside of this package that uses
+-- 'Polysemy.Internal.Union.weave' improperly.
+-- If this cannot possibly be the case, open an issue over at the
+-- GitHub repository.
 runFixpointM
     :: ( MonadFix m
        , Member (Embed m) r
@@ -36,6 +61,19 @@ runFixpointM
     -> Sem r a
 runFixpointM lower = interpretH $ \case
   Fixpoint mf -> do
-    c <- bindT mf
-    embed $ mfix $ lower . runFixpointM lower . c
+    c   <- bindT mf
+    s   <- getInitialStateT
+    ins <- getInspectorT
+    embed $ mfix $ \fa ->
+      lower . runFixpointM lower . c $
+        maybe (bomb "runFixpointM") id (inspect ins fa) <$ s
+{-# INLINE runFixpointM #-}
 
+
+bomb :: String -> a
+bomb str = error $
+    str ++ ": Uninspectable effectful state still\
+            \ contained an observable result.\
+            \ You're likely using an interpreter\
+            \ that uses 'weave' improperly.\
+            \ See documentation for more information."

--- a/src/Polysemy/Fixpoint.hs
+++ b/src/Polysemy/Fixpoint.hs
@@ -9,22 +9,44 @@ module Polysemy.Fixpoint
   ) where
 
 import Control.Monad.Fix
+import Data.Maybe
+
 import Polysemy
 import Polysemy.Internal.Fixpoint
 
 ------------------------------------------------------------------------------
 -- | Run a 'Fixpoint' effect purely.
 --
--- __Note__: 'runFixpoint' operates under the assumption that any effectful
+-- __Note__: This is subject to the same traps as 'MonadFix' instances for
+-- monads with failure: this will throw an exception if you try to recursively use
+-- the result of a failed computation in an action whose effect may be observed
+-- even though the computation failed.
+--
+-- For example, the following program will throw an exception upon evaluating the
+-- final state:
+-- @
+-- bad :: (Int, Either () Int)
+-- bad =
+--    run
+--  . runFixpoint run
+--  . runLazyState @Int 1
+--  . runError
+--  $ mdo
+--   put a
+--   a <- throw ()
+--   return a
+-- @
+--
+-- 'runFixpoint' also operates under the assumption that any effectful
 -- state which can't be inspected using 'Polysemy.Inspector' can't contain any
 -- values. This is true for all interpreters featured in this package,
 -- and is presumably always true for any properly implemented interpreter.
+-- 'runFixpoint' may throw an exception if it is used together with an
+-- interpreter that uses 'Polysemy.Internal.Union.weave' improperly.
 --
--- If 'runFixpoint' throws an exception for you, then you're likely using
--- some interpreter outside of this package that uses
--- 'Polysemy.Internal.Union.weave' improperly.
--- If this cannot possibly be the case, open an issue over at the
--- GitHub repository.
+-- If 'runFixpoint' throws an exception for you, and it can't
+-- be due to any of the above, then open an issue over at the
+-- GitHub repository for polysemy.
 runFixpoint
     :: (∀ x. Sem r x -> x)
     -> Sem (Fixpoint ': r) a
@@ -36,22 +58,13 @@ runFixpoint lower = interpretH $ \case
     ins <- getInspectorT
     pure $ fix $ \fa ->
       lower . runFixpoint lower . c $
-        maybe (bomb "runFixpoint") id (inspect ins fa) <$ s
+        fromMaybe (bomb "runFixpoint") (inspect ins fa) <$ s
 {-# INLINE runFixpoint #-}
 
 ------------------------------------------------------------------------------
 -- | Run a 'Fixpoint' effect in terms of an underlying 'MonadFix' instance.
 --
--- __Note__: 'runFixpointM' operates under the assumption that any effectful
--- state which can't be inspected using 'Polysemy.Inspector' can't contain any
--- values. This is true for all interpreters featured in this package,
--- and is presumably always true for any properly implemented interpreter.
---
--- If 'runFixpointM' throws an exception for you, then you're likely using
--- some interpreter outside of this package that uses
--- 'Polysemy.Internal.Union.weave' improperly.
--- If this cannot possibly be the case, open an issue over at the
--- GitHub repository.
+-- __Note__: 'runFixpointM' is subject to the same caveats as 'runFixpoint'.
 runFixpointM
     :: ( MonadFix m
        , Member (Embed m) r
@@ -66,14 +79,16 @@ runFixpointM lower = interpretH $ \case
     ins <- getInspectorT
     embed $ mfix $ \fa ->
       lower . runFixpointM lower . c $
-        maybe (bomb "runFixpointM") id (inspect ins fa) <$ s
+        fromMaybe (bomb "runFixpointM") (inspect ins fa) <$ s
 {-# INLINE runFixpointM #-}
 
 
 bomb :: String -> a
 bomb str = error $
-    str ++ ": Uninspectable effectful state still\
-            \ contained an observable result.\
-            \ You're likely using an interpreter\
+    str ++ ": Internal computation failed.\
+            \ This is likely because you have tried to recursively use\
+            \ the result of a failed computation in an action\
+            \ whose effect may be observed even though the computation failed.\
+            \ It's also possible that you're using an interpreter\
             \ that uses 'weave' improperly.\
             \ See documentation for more information."

--- a/test/FixpointSpec.hs
+++ b/test/FixpointSpec.hs
@@ -46,7 +46,7 @@ test2 =
   . runFixpoint run
   . runError
   $ mdo
-  a <- throw (1 : a) `catch` (\e -> return e)
+  a <- throw (2 : a) `catch` (\e -> return (1 : e))
   return a
 
 test3 :: Either () (Int, Int)
@@ -78,7 +78,7 @@ spec = parallel $ describe "runFixpoint" $ do
     test1 `shouldBe` ("12",  (2, ()))
   it "should work with runError" $ do
     let res = fmap (take 10) test2
-    res `shouldBe` Right (replicate 10 1)
+    res `shouldBe` Right (take 10 $ cycle [1,2])
   it "should not trigger the bomb" $ do
     test3 `shouldBe` Left ()
   it "should trigger the bomb" $ do

--- a/test/FixpointSpec.hs
+++ b/test/FixpointSpec.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecursiveDo #-}
+module FixpointSpec where
+
+import Control.Exception (try, evaluate)
+import Control.Monad.Fix
+
+import Polysemy
+import Polysemy.Fixpoint
+import Polysemy.Error
+import Polysemy.State
+import Polysemy.Output
+
+import Test.Hspec
+
+data FinalState s m a where
+  GetEventualState :: FinalState s m s
+
+makeSem ''FinalState
+
+runFinalState :: Member Fixpoint r
+              => s
+              -> Sem (State s ': FinalState s ': r) a
+              -> Sem r (s, a)
+runFinalState s sm = mfix $ \ ~(s', _) ->
+  interpret
+    (\GetEventualState -> pure s')
+    (runState s sm)
+
+test1 :: (String, (Int, ()))
+test1 =
+    run
+  . runFixpoint run
+  . runOutputMonoid (show @Int)
+  . runFinalState 1
+  $ do
+  s  <- get @Int
+  s' <- getEventualState @Int
+  output @Int s
+  output @Int s'
+  put @Int 2
+
+test2 :: Either [Int] [Int]
+test2 =
+    run
+  . runFixpoint run
+  . runError
+  $ mdo
+  a <- throw (1 : a) `catch` (\e -> return e)
+  return a
+
+test3 :: Either () (Int, Int)
+test3 =
+    run
+  . runFixpoint run
+  . runError
+  . runLazyState @Int 1
+  $ mdo
+  put a
+  a <- throw ()
+  return a
+
+test4 :: (Int, Either () Int)
+test4 =
+    run
+  . runFixpoint run
+  . runLazyState @Int 1
+  . runError
+  $ mdo
+  put a
+  a <- throw ()
+  return a
+
+
+spec :: Spec
+spec = parallel $ describe "runFixpoint" $ do
+  it "should work with runState" $ do
+    test1 `shouldBe` ("12",  (2, ()))
+  it "should work with runError" $ do
+    let res = fmap (take 10) test2
+    res `shouldBe` Right (replicate 10 1)
+  it "should not trigger the bomb" $ do
+    test3 `shouldBe` Left ()
+  it "should trigger the bomb" $ do
+    let (s, a) = test4
+    evaluate s `shouldThrow` errorCall bombMessage
+    a `shouldBe` Left ()
+
+bombMessage :: String
+bombMessage =
+  "runFixpoint: Internal computation failed.\
+              \ This is likely because you have tried to recursively use\
+              \ the result of a failed computation in an action\
+              \ whose effect may be observed even though the computation failed.\
+              \ It's also possible that you're using an interpreter\
+              \ that uses 'weave' improperly.\
+              \ See documentation for more information."


### PR DESCRIPTION
I stumbled across this interesting improvement to the semantics of `Fixpoint` interpreters.

The big problem with the current interpreters of fixpoint is that they diverge if any distribution law `forall x. f (m x) -> Sem r (f x)` of any `Weaving` is strict in the functorial state, which they pretty much _always are_ if you have run any return-value changing interpreter such as `runState` and `runError`.

However, it's possible to improve upon this by taking cues from the `MonadFix` implementations of `StateT` and `ExceptT`. Instead of using the recursive functorial state, we could use the initial state. Because of this, we need to extract the encapsulated value of the recursive state in order to have something to provide to the function. We can do that using the inspector, inserting a deferred bomb if the inspector fails. The idea here is that if the inspector failed, then the resulting functorial state can't contain any values; thus, embedding the bomb doesn't pose any issue, as it won't be observable.

Through this mechanism, `Fixpoint` becomes a lot more powerful than it used to be. Previously, it required that any effects with result-value changing interpreters are interpreted in the final monad, but now, you can use `runFixpoint` safely together with `runError`, and `runState`.

This isn't a perfect solution, however; unfortunately, the interaction with `runNonDet` doesn't reflect that of the list monad's `MonadFix` instance. (Which is a possible argument for why you'd want a `lowerNonDet` interpreter to solve that)

Another flaw of this solution is that it hinges on the implication that if the inspector fails, then the functorial state doesn't contain any values. This is true for all interpreters in polysemy, but it's easy to violate it if you decide to write your own return-value changing interpreter and just provide `const Nothing` as the inspector when you `weave`.

What's your opinion of this @isovector ? I'll return in a while to write some proper tests.