### PR TITLE
Add runOutputSem interpreter

### DIFF
--- a/src/Polysemy/Output.hs
+++ b/src/Polysemy/Output.hs
@@ -12,6 +12,7 @@ module Polysemy.Output
   , runOutputMonoid
   , ignoreOutput
   , runOutputBatched
+  , runOutputSem
   ) where
 
 import Data.Bifunctor (first)
@@ -101,3 +102,10 @@ runOutputBatched size m = do
   when (c > 0) $ output @[o] (reverse res)
   pure a
 
+------------------------------------------------------------------------------
+-- | Runs an 'Output' effect by running a monadic action for each of its
+-- values.
+runOutputSem :: (o -> Sem r ()) -> Sem (Output o ': r) a -> Sem r a
+runOutputSem act = interpret $ \case
+    Output o -> act o
+{-# INLINE runOutputSem #-}


### PR DESCRIPTION
Adds a `runOutputSem` interpreter, which runs a monadic action over each output value. Similar to `runInputSem` for `Input`

Not sure if it belongs in the library (it feels _too simple_, like runInputSem does), but [I've found it useful in my projects](https://github.com/cnr/discord-hs/blob/6983b4f545aa883fe3515432377bdc4da08789eb/src/Discord/Gateway.hs#L126-L127)