### PR TITLE
Hide visibility of Polysemy.Fixpoint.bomb, fix changelog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,13 +30,13 @@
 - Renamed `runTraceAsOutput` to `traceToOutput`
 - Renamed `runTraceIO` to `traceToIO`
 - Renamed `sendM` to `embed` (thanks to @googleson78)
-- The `NonDet` effect will no longer perform effects in untaken branches (thanks to @KingoftheHomeless)
+- The `NonDet` effect is now higher-order (thanks to @KingoftheHomeless)
 
 ### Other Changes
 
 - Added `evalState` and `evalLazyState`
 - Added `runNonDetMaybe` (thanks to @KingoftheHomeless)
-- Added `nonDetToMaybe` (thanks to @KingoftheHomeless)
+- Added `nonDetToError` (thanks to @KingoftheHomeless)
 - Haddock documentation for smart constructors generated via `makeSem` will no
     longer have weird variable names (thanks to @TheMatten)
 

--- a/src/Polysemy/Fixpoint.hs
+++ b/src/Polysemy/Fixpoint.hs
@@ -81,14 +81,3 @@ runFixpointM lower = interpretH $ \case
       lower . runFixpointM lower . c $
         fromMaybe (bomb "runFixpointM") (inspect ins fa) <$ s
 {-# INLINE runFixpointM #-}
-
-
-bomb :: String -> a
-bomb str = error $
-    str ++ ": Internal computation failed.\
-            \ This is likely because you have tried to recursively use\
-            \ the result of a failed computation in an action\
-            \ whose effect may be observed even though the computation failed.\
-            \ It's also possible that you're using an interpreter\
-            \ that uses 'weave' improperly.\
-            \ See documentation for more information."

--- a/src/Polysemy/Internal/Fixpoint.hs
+++ b/src/Polysemy/Internal/Fixpoint.hs
@@ -7,3 +7,18 @@ module Polysemy.Internal.Fixpoint where
 data Fixpoint m a where
   Fixpoint :: (a -> m a) -> Fixpoint m a
 
+
+------------------------------------------------------------------------------
+-- | The error used in 'Polysemy.Fixpoint.runFixpoint' and
+-- 'Polysemy.Fixpoint.runFixpointM' when the result of a failed computation
+-- is recursively used and somehow visible. You may use this for your own
+-- 'Fixpoint' interpreters. The argument should be the name of the interpreter.
+bomb :: String -> a
+bomb str = error $
+    str ++ ": Internal computation failed.\
+            \ This is likely because you have tried to recursively use\
+            \ the result of a failed computation in an action\
+            \ whose effect may be observed even though the computation failed.\
+            \ It's also possible that you're using an interpreter\
+            \ that uses 'weave' improperly.\
+            \ See documentation for more information."


### PR DESCRIPTION
I accidentally exported the `bomb` in `Polysemy.Fixpoint`, so this moves it to the internal module.

I also fixed some minor errors in the changelog of v1.