### PR TITLE
Add right-associative variants of runOutputMonoid and runWriter

### DIFF
--- a/src/Polysemy/Writer.hs
+++ b/src/Polysemy/Writer.hs
@@ -100,7 +100,7 @@ runWriterAssocR =
        => Sem (Writer o ': r) a
        -> Sem r (o -> o, a)
     go =
-        runState mempty
+        runState id
       . reinterpretH
       (\case
           Tell o -> do


### PR DESCRIPTION
`runOutputMonoid` and `runWriter` combine the monoidal values left-associatively, which results in terrible performance when used together with linked lists such as `String`. This can be addressed by instead using `DList a`/`Endo [a]` as the monoid, which, through some CPS magic, effectively "right-associates" uses of `<>`, making lists behave asymptotically better.

I figured we could add interpreters that automate the conversions between a monoid and its `Endo` variant, and therefore do all this wrangling under the hood, so that's what this pull request is about.

Right now, the interpreters are called `runOutputMonoidAssocR` and `runWriterAssocR`, which I don't particularly like. Does anyone have suggestions for better names?