### PR TITLE
Improve choice of functorial state for runNonDet

### DIFF
--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -23,8 +23,8 @@ module Polysemy
     --
     -- @
     -- data Console m a where
-    --   WriteLine :: 'String' -> Console m ()
-    --   ReadLine  :: Console m 'String'
+    --   WriteLine :: String -> Console m ()
+    --   ReadLine  :: Console m String
     -- @
     --
     -- Notice that the @a@ parameter gets instantiated at the /desired return/
@@ -41,7 +41,7 @@ module Polysemy
     --
     -- @
     -- writeLine :: 'Member' Console r => String -> 'Sem' r ()
-    -- readLine  :: 'Member' Console r => 'Sem' r 'String'
+    -- readLine  :: 'Member' Console r => 'Sem' r String
     -- @
     --
     -- Effects which don't make use of the @m@ parameter are known as

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -23,12 +23,12 @@ module Polysemy
     --
     -- @
     -- data Console m a where
-    --   WriteLine :: String -> Console m ()
-    --   ReadLine  :: Console m String
+    --   WriteLine :: 'String' -> Console m ()
+    --   ReadLine  :: Console m 'String'
     -- @
     --
-    -- Notice that the @a@ parameter gets instataniated at the /desired return
-    -- type/ of the actions. Writing a line returns a '()', but reading one
+    -- Notice that the @a@ parameter gets instantiated at the /desired return/
+    -- /type/ of the actions. Writing a line returns a @()@, but reading one
     -- returns 'String'.
     --
     -- By enabling @-XTemplateHaskell@, we can use the 'makeSem' function
@@ -41,7 +41,7 @@ module Polysemy
     --
     -- @
     -- writeLine :: 'Member' Console r => String -> 'Sem' r ()
-    -- readLine  :: 'Member' Console r => 'Sem' r String
+    -- readLine  :: 'Member' Console r => 'Sem' r 'String'
     -- @
     --
     -- Effects which don't make use of the @m@ parameter are known as

--- a/src/Polysemy/Fixpoint.hs
+++ b/src/Polysemy/Fixpoint.hs
@@ -24,6 +24,7 @@ import Polysemy.Internal.Fixpoint
 --
 -- For example, the following program will throw an exception upon evaluating the
 -- final state:
+--
 -- @
 -- bad :: (Int, Either () Int)
 -- bad =

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -272,7 +272,7 @@ instance (Member NonDet r) => MonadPlus (Sem r) where
   mzero = empty
   mplus = (<|>)
 
--- | TODO: @since _
+-- | @since 1.1.0.0
 instance (Member Fail r) => MonadFail (Sem r) where
   fail = send . Fail
   {-# INLINE fail #-}

--- a/src/Polysemy/NonDet.hs
+++ b/src/Polysemy/NonDet.hs
@@ -13,70 +13,18 @@ module Polysemy.NonDet
 
 import Control.Applicative
 import Control.Monad.Trans.Maybe
-import Data.Maybe
+
 import Polysemy
 import Polysemy.Error
 import Polysemy.Internal
 import Polysemy.Internal.NonDet
 import Polysemy.Internal.Union
 
-
---------------------------------------------------------------------------------
--- This stuff is lifted from 'fused-effects'. Thanks guys!
-runNonDetC :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
-runNonDetC (NonDetC m) = m (fmap . (<|>) . pure) (pure empty)
-{-# INLINE runNonDetC #-}
-
-
-newtype NonDetC m a = NonDetC
-  { -- | A higher-order function receiving two parameters: a function to combine
-    -- each solution with the rest of the solutions, and an action to run when no
-    -- results are produced.
-    unNonDetC :: forall b . (a -> m b -> m b) -> m b -> m b
-  }
-  deriving (Functor)
-
-instance Applicative (NonDetC m) where
-  pure a = NonDetC (\ cons -> cons a)
-  {-# INLINE pure #-}
-
-  NonDetC f <*> NonDetC a = NonDetC $ \ cons ->
-    f (\ f' -> a (cons . f'))
-  {-# INLINE (<*>) #-}
-
-instance Alternative (NonDetC m) where
-  empty = NonDetC (\ _ nil -> nil)
-  {-# INLINE empty #-}
-
-  NonDetC l <|> NonDetC r = NonDetC $ \ cons -> l cons . r cons
-  {-# INLINE (<|>) #-}
-
-instance Monad (NonDetC m) where
-  NonDetC a >>= f = NonDetC $ \ cons ->
-    a (\ a' -> unNonDetC (f a') cons)
-  {-# INLINE (>>=) #-}
-
-
 ------------------------------------------------------------------------------
 -- | Run a 'NonDet' effect in terms of some underlying 'Alternative' @f@.
 runNonDet :: Alternative f => Sem (NonDet ': r) a -> Sem r (f a)
 runNonDet = runNonDetC . runNonDetInC
 {-# INLINE runNonDet #-}
-
-runNonDetInC :: Sem (NonDet ': r) a -> NonDetC (Sem r) a
-runNonDetInC = usingSem $ \u ->
-  case decomp u of
-    Left x  -> NonDetC $ \cons nil -> do
-      z <- liftSem $ weave [()]
-                     (fmap concat . traverse runNonDet)
-                     -- TODO(sandy): Is this the right semantics?
-                     listToMaybe
-                     x
-      foldr cons nil z
-    Right (Weaving Empty _ _ _ _) -> empty
-    Right (Weaving (Choose left right) s wv ex _) -> fmap ex $
-      runNonDetInC (wv (left <$ s)) <|> runNonDetInC (wv (right <$ s))
-{-# INLINE runNonDetInC #-}
 
 ------------------------------------------------------------------------------
 -- | Run a 'NonDet' effect in terms of an underlying 'Maybe'
@@ -116,3 +64,93 @@ nonDetToError (e :: e) = interpretH $ \case
     right' <- nonDetToError e <$> runT right
     raise (left' `catch` \(_ :: e) -> right')
 {-# INLINE nonDetToError #-}
+
+
+--------------------------------------------------------------------------------
+-- This stuff is lifted from 'fused-effects'. Thanks guys!
+runNonDetC :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
+runNonDetC (NonDetC m) = m (fmap . (<|>) . pure) (pure empty)
+{-# INLINE runNonDetC #-}
+
+
+newtype NonDetC m a = NonDetC
+  { -- | A higher-order function receiving two parameters: a function to combine
+    -- each solution with the rest of the solutions, and an action to run when no
+    -- results are produced.
+    unNonDetC :: forall b . (a -> m b -> m b) -> m b -> m b
+  }
+  deriving (Functor)
+
+instance Applicative (NonDetC m) where
+  pure a = NonDetC (\ cons -> cons a)
+  {-# INLINE pure #-}
+
+  NonDetC f <*> NonDetC a = NonDetC $ \ cons ->
+    f (\ f' -> a (cons . f'))
+  {-# INLINE (<*>) #-}
+
+instance Alternative (NonDetC m) where
+  empty = NonDetC (\ _ nil -> nil)
+  {-# INLINE empty #-}
+
+  NonDetC l <|> NonDetC r = NonDetC $ \ cons -> l cons . r cons
+  {-# INLINE (<|>) #-}
+
+instance Monad (NonDetC m) where
+  NonDetC a >>= f = NonDetC $ \ cons ->
+    a (\ a' -> unNonDetC (f a') cons)
+  {-# INLINE (>>=) #-}
+
+runNonDetInC :: Sem (NonDet ': r) a -> NonDetC (Sem r) a
+runNonDetInC = usingSem $ \u ->
+  case decomp u of
+    Left x  -> consC $ fmap getNonDetState $
+      liftSem $ weave (NonDetState (Just ((), empty)))
+                  distribNonDetC
+                  -- TODO(KingoftheHomeless): Is THIS the right semantics?
+                  (fmap fst . getNonDetState)
+                  x
+    Right (Weaving Empty _ _ _ _) -> empty
+    Right (Weaving (Choose left right) s wv ex _) -> fmap ex $
+      runNonDetInC (wv (left <$ s)) <|> runNonDetInC (wv (right <$ s))
+{-# INLINE runNonDetInC #-}
+
+-- This choice of functorial state is inspired from the
+-- MonadBaseControl instance for 'ListT' from 'list-t'.
+--
+-- TODO(KingoftheHomeless):
+-- Is there a different representation of this which doesn't require
+-- 'unconsC' in 'distribNonDetC'?
+newtype NonDetState r a = NonDetState {
+  getNonDetState :: Maybe (a, NonDetC (Sem r) a)
+  } deriving (Functor)
+
+-- KingoftheHomeless: The performance of this is terrible
+-- since unconsC is O(n), but this really only matters if
+--
+--   1. You have higher-order effects interpreted after 'NonDet'
+--
+--   2. You use '<|>' a /lot/ inside higher-order actions of those effects.
+--
+-- You can fix this by instead creating a NonDet carrier based upon
+-- reflection without remorse, but that would require a lot of work, and will
+-- slightly degrade performance when this ISN'T a problem.
+-- Question is if it's worth it.
+distribNonDetC :: NonDetState r (Sem (NonDet ': r) a) -> Sem r (NonDetState r a)
+distribNonDetC = \case
+  NonDetState (Just (a, r)) ->
+    fmap NonDetState $ unconsC $ runNonDetInC a <|> (r >>= runNonDetInC)
+  _ ->
+    pure (NonDetState Nothing)
+{-# INLINE distribNonDetC #-}
+
+-- O(n)
+unconsC :: NonDetC (Sem r) a -> Sem r (Maybe (a, NonDetC (Sem r) a))
+unconsC (NonDetC n) = n (\a r -> pure (Just (a, consC r))) (pure Nothing)
+{-# INLINE unconsC #-}
+
+consC :: Sem r (Maybe (a, NonDetC (Sem r) a)) -> NonDetC (Sem r) a
+consC m = NonDetC $ \cons nil -> m >>= \case
+  Just (a, r) -> cons a (unNonDetC r cons nil)
+  _           -> nil
+{-# INLINE consC #-}

--- a/src/Polysemy/NonDet.hs
+++ b/src/Polysemy/NonDet.hs
@@ -125,17 +125,9 @@ newtype NonDetState r a = NonDetState {
   getNonDetState :: Maybe (a, NonDetC (Sem r) a)
   } deriving (Functor)
 
--- KingoftheHomeless: The performance of this is terrible
--- since unconsC is O(n), but this really only matters if
---
---   1. You have higher-order effects interpreted after 'NonDet'
---
---   2. You use '<|>' a /lot/ inside higher-order actions of those effects.
---
--- You can fix this by instead creating a NonDet carrier based upon
--- reflection without remorse, but that would require a lot of work, and will
--- slightly degrade performance when this ISN'T a problem.
--- Question is if it's worth it.
+-- KingoftheHomeless: The performance of this could be improved
+-- if we weren't forced to use unconsC, which causes this to have
+-- potentially O(n^2) behaviour.
 distribNonDetC :: NonDetState r (Sem (NonDet ': r) a) -> Sem r (NonDetState r a)
 distribNonDetC = \case
   NonDetState (Just (a, r)) ->


### PR DESCRIPTION
I discovered while working on polysemy-zoo that `runNonDet` plays really badly with `Cont`, no matter how `Cont` is interpreted.

Consider this example, using the most reliable interpreters available (this uses https://github.com/polysemy-research/polysemy-zoo/pull/45):
```haskell
knot :: Member (Cont ref) r => a -> Sem r (a, a -> Sem r b)
knot a = callCC $ \c -> let b x = c (x, b) in pure (a, b)

bad :: IO [Int]
bad = do
  ref <- newIORef []
  _ <-  (`runContT` pure)
      . runFinal
      . embedToFinal
      . embedToMonadIO
      . contToFinal
      . runOutputMonoidIORef ref (:[])
      . runReader ()
      . runNonDet @[]
      $ do
        (end, (i, loop)) <- local id $ ((,) 10 <$> knot 1) <|> ((,) 8 <$> knot 2)
        output i
        when (i < end) $
          loop $! i + 1
  readIORef ref
```
Without the `local id`, this does what you'd expect: return `[1,2,3,4,5,6,7,8,9,10,2,3,4,5,6,7,8]`.
With the `local id`, however, this returns `[1,2,3,4,5,6,7,8,9,10,2,10,3,10,4,10,5,10,6,10,7,10,8]`!

I tracked this down to the choice of functorial state that is used when weaving through other effects in `runNonDet`; `[]`. So I took a cue from the instance of `MonadBaseControl` for `ListT` in the `list-t` package, and replaced the functorial state with one that fixes this bug!

Here's the thing, however; the change in functorial state makes the weaving of other higher-order actions in `runNonDet` extremely less efficient if the higher-order action is heavy in `<|>`. I haven't been able to figure out if the choice of `[]` as the functorial state has any other adverse effects except for the wrong interaction with `Cont`, so the question is if this change is worth it.