### PR TITLE
polysemy-plugin: Reject ununifiable effect candidates early

### DIFF
--- a/polysemy-plugin/ChangeLog.md
+++ b/polysemy-plugin/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog for polysemy-plugin
 
+
+## 0.2.3.0 (TODO)
+- The plugin will now choose between given effects based on the ability to unify them.
+    This makes it possible for disambiguation to kick in even when using multiple
+    instances of the same effect with different type variables,
+    as long as type annotations/applications are used to
+    target a specific instance.
+- Updated the test suite to test against `polysemy-1.2.0.0`.
+
 ## 0.2.2.0 (2019-07-04)
 
 - The plugin will now prevent some false-positives in `polysemy`'s error

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -1,5 +1,5 @@
 name:                polysemy-plugin
-version:             0.2.2.0
+version:             0.2.3.0
 github:              "isovector/polysemy"
 license:             BSD3
 author:              "Sandy Maguire"

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9e8afb18feb1e62c82854e11adcc4998c4d92ca41c69fe57da93dbec4b7cd490
+-- hash: 01634ce3c7ac101e60c1a02f8ccad7ec499c02a04b66e5d9dd5993f314318097
 
 name:           polysemy-plugin
-version:        0.2.2.0
+version:        0.2.3.0
 synopsis:       Disambiguate obvious uses of effects.
 description:    Please see the README on GitHub at <https://github.com/isovector/polysemy/tree/master/polysemy-plugin#readme>
 category:       Polysemy

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a3e70728f8ab4d2e3e7b2727e004b88a497852dd2b44df914418e070f5171e92
+-- hash: 9e8afb18feb1e62c82854e11adcc4998c4d92ca41c69fe57da93dbec4b7cd490
 
 name:           polysemy-plugin
 version:        0.2.2.0
@@ -58,6 +58,7 @@ test-suite polysemy-plugin-test
       DoctestSpec
       ExampleSpec
       LegitimateTypeErrorSpec
+      MultipleVarsSpec
       PluginSpec
       TypeErrors
       VDQSpec

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -116,12 +116,12 @@ mkWantedForce
   -> Type
   -> TcPluginM (Unification, Ct)
 mkWantedForce fc given = do
-    (ev, _) <- unsafeTcPluginTcM
-             . runTcSDeriveds
-             $ newWantedEq (fcLoc fc) Nominal wanted given
-    pure ( Unification (OrdType wanted) (OrdType given)
-         , CNonCanonical ev
-         )
+  (ev, _) <- unsafeTcPluginTcM
+           . runTcSDeriveds
+           $ newWantedEq (fcLoc fc) Nominal wanted given
+  pure ( Unification (OrdType wanted) (OrdType given)
+       , CNonCanonical ev
+       )
   where
     wanted = fcEffect fc
 

--- a/polysemy-plugin/test/MultipleVarsSpec.hs
+++ b/polysemy-plugin/test/MultipleVarsSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
+
+module MultipleVarsSpec where
+
+import Polysemy
+
+import Test.Hspec
+
+data TaggedState k s m a where
+  TaggedGet :: forall k s m. TaggedState k s m s
+  TaggedPut :: forall k s m. s -> TaggedState k s m ()
+
+makeSem ''TaggedState
+
+test :: Members '[
+          TaggedState Char Int
+        , TaggedState Bool Int
+        ] r
+      => Sem r ()
+test = taggedPut @Bool 10
+
+
+spec :: Spec
+spec = describe "Using multiple, but ununifiable instances\
+               \ of the same effect" $ do
+  it "should get disambiguated and compile!" $ do
+    True `shouldBe` True

--- a/polysemy-plugin/test/MultipleVarsSpec.hs
+++ b/polysemy-plugin/test/MultipleVarsSpec.hs
@@ -4,6 +4,7 @@
 module MultipleVarsSpec where
 
 import Polysemy
+import Polysemy.State
 
 import Test.Hspec
 
@@ -13,16 +14,49 @@ data TaggedState k s m a where
 
 makeSem ''TaggedState
 
+runTaggedState :: forall k s r a
+                . s
+               -> Sem (TaggedState k s ': r) a
+               -> Sem r (s, a)
+runTaggedState s =
+    (runState s .)
+  $ reinterpret
+  $ \case
+    TaggedGet -> get
+    TaggedPut s -> put s
+
 test :: Members '[
           TaggedState Char Int
         , TaggedState Bool Int
         ] r
-      => Sem r ()
-test = taggedPut @Bool 10
-
+     => Sem r ()
+test = do
+  taggedPut @Bool 10
+  taggedPut @Char (-10)
 
 spec :: Spec
 spec = describe "Using multiple, but ununifiable instances\
                \ of the same effect" $ do
-  it "should get disambiguated and compile!" $ do
-    True `shouldBe` True
+  it "should get disambiguated and compile, \
+     \and actions should target the right effects." $ do
+    let
+      res1 =
+          run
+        . runTaggedState @Char 0
+        . runTaggedState @Bool 7
+        $ test
+      res2 =
+          run
+        . runTaggedState @Bool 0
+        . runTaggedState @Char 7
+        $ test
+      res3 =
+          run
+        . runTaggedState @Bool 0
+        . runTaggedState @Char 7
+        $ do
+          taggedPut @Bool 10
+          taggedPut @Char (-10)
+    res1 `shouldBe` (-10, (10, ()))
+    res2 `shouldBe` (10, (-10, ()))
+    res3 `shouldBe` (10, (-10, ()))


### PR DESCRIPTION
This is the improvement I described in #219. 

Any other improvements may be a long way off, if I even find a way to do them, so I figured I'd open this pull request separately for the easy fix.