### PR TITLE
Add tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Or by adding `-fplugin=Polysemy.Plugin` to your package.yaml/.cabal file `ghc-op
 <sup><a name="fn1">1</a></sup>: Unfortunately this is not true in GHC 8.6.3, but
 will be true in GHC 8.10.1.
 
+## Tutorial
+
+Raghu Kaippully wrote a beginner friendly [tutorial](https://haskell-explained.gitlab.io/blog/posts/2019/07/28/polysemy-is-cool-part-1/index.html).
 
 ## Examples
 


### PR DESCRIPTION
I added a link to an article series on Raghu Kaippully's blog. For me at least it, somewhere in the limbo between books and actually writing production Haskell code, it was a very clear introduction.

I don't know if this needed to be a pull request or just an issue.