### PR TITLE
Add type synonym 'InterpreterFor' and documentation

### DIFF
--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -136,11 +136,11 @@ module Polysemy
   , Inspector (..)
   ) where
 
-import           Polysemy.Final
-import           Polysemy.Internal
-import           Polysemy.Internal.Combinators
-import           Polysemy.Internal.Forklift
-import           Polysemy.Internal.Kind
-import           Polysemy.Internal.Tactics
-import           Polysemy.Internal.TH.Effect
+import Polysemy.Final
+import Polysemy.Internal
+import Polysemy.Internal.Combinators
+import Polysemy.Internal.Forklift
+import Polysemy.Internal.Kind
+import Polysemy.Internal.Tactics
+import Polysemy.Internal.TH.Effect
 

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -9,15 +9,15 @@ module Polysemy
   , runM
   , runFinal
 
+  -- * Type synonyms for user convenience
+  , InterpreterFor
+
   -- * Interoperating With Other Monads
   -- ** Embed
   , Embed (..)
   , embed
   , embedToFinal
 
-  -- * Type synonyms for user convenience
-  -- ** InterpreterFor
-  , InterpreterFor
   -- ** Final
   -- | For advanced uses of 'Final', including creating your own interpreters
   -- that make use of it, see "Polysemy.Final"

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -14,6 +14,10 @@ module Polysemy
   , Embed (..)
   , embed
   , embedToFinal
+
+  -- * Type synonyms for user convenience
+  -- ** InterpreterFor
+  , InterpreterFor
   -- ** Final
   -- | For advanced uses of 'Final', including creating your own interpreters
   -- that make use of it, see "Polysemy.Final"
@@ -132,11 +136,11 @@ module Polysemy
   , Inspector (..)
   ) where
 
-import Polysemy.Internal
-import Polysemy.Internal.Combinators
-import Polysemy.Internal.Forklift
-import Polysemy.Internal.Kind
-import Polysemy.Internal.TH.Effect
-import Polysemy.Internal.Tactics
-import Polysemy.Final
+import           Polysemy.Final
+import           Polysemy.Internal
+import           Polysemy.Internal.Combinators
+import           Polysemy.Internal.Forklift
+import           Polysemy.Internal.Kind
+import           Polysemy.Internal.Tactics
+import           Polysemy.Internal.TH.Effect
 

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -23,6 +23,7 @@ module Polysemy.Internal
   , usingSem
   , liftSem
   , hoistSem
+  , InterpreterFor
   , (.@)
   , (.@@)
   ) where
@@ -434,6 +435,18 @@ runM (Sem m) = m $ \z ->
       pure $ f $ a <$ s
 {-# INLINE runM #-}
 
+------------------------------------------------------------------------------
+-- | Type synonym for interpreters that consume an effect without changing the 
+-- return value. Offered for user convenience. 
+--
+-- 'r' Is kept polymorphic so it's possible to place constraints upon it:
+--
+-- @
+-- teletypeToIO
+-- :: 'Member' (Embed IO) r
+-- => 'InterpreterFor' Teletype r
+-- @
+type InterpreterFor e r = forall a. Sem (e ': r) a -> Sem r a
 
 ------------------------------------------------------------------------------
 -- | Some interpreters need to be able to lower down to the base monad (often

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -439,12 +439,11 @@ runM (Sem m) = m $ \z ->
 -- | Type synonym for interpreters that consume an effect without changing the 
 -- return value. Offered for user convenience. 
 --
--- 'r' Is kept polymorphic so it's possible to place constraints upon it:
+-- @r@ Is kept polymorphic so it's possible to place constraints upon it:
 --
 -- @
--- teletypeToIO
--- :: 'Member' (Embed IO) r
--- => 'InterpreterFor' Teletype r
+-- teletypeToIO :: 'Member' (Embed IO) r
+--              => 'InterpreterFor' Teletype r
 -- @
 type InterpreterFor e r = forall a. Sem (e ': r) a -> Sem r a
 


### PR DESCRIPTION
Hi,

This PR tackles issue #220 . I've put the type synonym on the Polysemy.Internal module and documented it.

Please let me know if I should improve anything.