### PR TITLE
Let plugin solve stuck type rows + bug fixes in interpreter mode

### DIFF
--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 01634ce3c7ac101e60c1a02f8ccad7ec499c02a04b66e5d9dd5993f314318097
+-- hash: 6aabb881334585f56358446f23bcdff48fa22af05afc52c83a102db79c9ccd06
 
 name:           polysemy-plugin
 version:        0.2.3.0
@@ -57,9 +57,11 @@ test-suite polysemy-plugin-test
       BadSpec
       DoctestSpec
       ExampleSpec
+      HistorySpec
       LegitimateTypeErrorSpec
       MultipleVarsSpec
       PluginSpec
+      SpecificitySpec
       TypeErrors
       VDQSpec
       Paths_polysemy_plugin

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -5,7 +5,7 @@
 #if MIN_VERSION_ghc(8,5,0)
 #else
 #define EvExpr
-#define Coercion TcCoercion
+#define Coercion evCoercion
 -- #if __GLASGOW_HASKELL__ < 711
 --                     $ TcCoercion
 -- #endif

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -1,5 +1,14 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ViewPatterns               #-}
+
+#if MIN_VERSION_ghc(8,5,0)
+#else
+#define EvExpr EvCoercion
+-- #if __GLASGOW_HASKELL__ < 711
+--                     $ TcCoercion
+-- #endif
+#endif
 
 ------------------------------------------------------------------------------
 -- The MIT License (MIT)

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -303,8 +303,8 @@ getFounds stuff cts = sequenceA $ do
   Just (foundTc, [_, r, e]) <- pure $ splitTyConApp_maybe t1
   guard $ foundTc == foundTyCon stuff
 
+  let EvExpr evidence = evByFiat "polysemy-plugin" t1 nat
   let unrolled = unrollR r
-      EvExpr evidence = evByFiat "polysemy-plugin" t1 nat
       proof = CNonCanonical <$> newGiven (ctLoc ct) (mkPrimEqPred t1 nat) evidence
 
   case fmap fst $ find (eqType e . snd) $ zip [0..] unrolled of

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -5,6 +5,7 @@
 #if MIN_VERSION_ghc(8,5,0)
 #else
 #define EvExpr
+#define Coercion TcCoercion
 -- #if __GLASGOW_HASKELL__ < 711
 --                     $ TcCoercion
 -- #endif

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -56,6 +56,7 @@ import           TcSMonad hiding (tcLookupClass)
 import           Type
 import CoreSyn
 import GhcPlugins
+import GHC.TcPluginM.Extra (evByFiat)
 
 import Outputable
 
@@ -285,7 +286,7 @@ getIndexOfFounds stuff cts = do
   guard $ eqType e e'
   -- Just index <- pure $ fmap fst $ find (eqType e . snd) $ zip [0..] $ unfoldR r
   -- guard $ mkNat stuff index `eqType` nat
-  pure (EvExpr $ Coercion $ mkTcNomReflCo e, ct)
+  pure (evByFiat "polysemy-plugin" t1 e, ct)
 
 getFounds :: PolysemyStuff 'Things -> [Ct] -> [(EvTerm, Ct)]
 getFounds stuff cts = do
@@ -296,7 +297,7 @@ getFounds stuff cts = do
   guard $ foundTc == foundTyCon stuff
   Just index <- pure $ fmap fst $ find (eqType e . snd) $ zip [0..] $ unfoldR r
   guard $ mkNat stuff index `eqType` nat
-  pure (EvExpr $ Coercion $ mkTcNomReflCo nat, ct)
+  pure (evByFiat "polysemy-plugin" t1 nat, ct)
 
 
 mkNat :: PolysemyStuff 'Things -> Int -> Type

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -4,7 +4,7 @@
 
 #if MIN_VERSION_ghc(8,5,0)
 #else
-#define EvExpr EvCoercion
+#define EvExpr
 -- #if __GLASGOW_HASKELL__ < 711
 --                     $ TcCoercion
 -- #endif

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep.hs
@@ -5,7 +5,7 @@
 #if MIN_VERSION_ghc(8,5,0)
 #else
 #define EvExpr
-#define Coercion evCoercion
+#define Coercion EvCoercion
 -- #if __GLASGOW_HASKELL__ < 711
 --                     $ TcCoercion
 -- #endif

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
@@ -3,15 +3,14 @@ module Polysemy.Plugin.Fundep.Unification where
 import           Control.Arrow ((&&&))
 import           Data.Bool
 import           Data.Function (on)
+import           Data.Generics
+import           Data.List
+import           Data.Ord
 import qualified Data.Set as S
+import           DataCon (DataCon)
+import           Outputable hiding ((<>))
 import           TcRnTypes
 import           Type
-import Data.List
-import Data.Ord
-import DataCon (DataCon)
-import Data.Generics
-
-import Outputable hiding ((<>))
 
 
 ------------------------------------------------------------------------------

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
@@ -156,14 +156,3 @@ instance Eq OrdType where
 instance Ord OrdType where
   compare = nonDetCmpType `on` getOrdType
 
-
-------------------------------------------------------------------------------
--- | Filter out the unifications we've already emitted, and then give back the
--- things we should put into the @S.Set Unification@, and the new constraints
--- we should emit.
-unzipNewWanteds
-    :: S.Set Unification
-    -> [Unification]
-    -> [Unification]
-unzipNewWanteds old = filter (not . flip S.member old)
-

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
@@ -129,8 +129,11 @@ getGoodUnifications = fmap mostSpecificUnification . groupUnifications
 
 
 groupUnifications :: [Unification] -> [[Unification]]
-groupUnifications =
-  fmap (fmap snd) . groupBy ((==) `on` fst) . sortBy (comparing fst) . fmap (_unifyRHS &&& id)
+groupUnifications = fmap (fmap snd)
+                  . groupBy ((==) `on` fst)
+                  . sortBy (comparing fst)
+                  . fmap (_unifyRHS &&& id)
+
 
 specificityMetric :: Type -> Int
 specificityMetric = everything (+) $ mkQ 0 $ \case

--- a/polysemy-plugin/test/HistorySpec.hs
+++ b/polysemy-plugin/test/HistorySpec.hs
@@ -11,27 +11,75 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
-{-# OPTIONS_GHC
-     -fplugin=Polysemy.Plugin
-     -fdefer-type-errors
-     #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin -fconstraint-solver-iterations=10 #-}
 
 module HistorySpec where
 
 import Polysemy
 import Polysemy.State
-import Polysemy.Internal
-import Polysemy.Internal.Union
-import Data.Functor.Identity
 import Test.Hspec
+
+data History s m a where
+  Undo :: History s m ()
+  Redo :: History s m ()
+  PutAndForget :: s -> History s m ()
+
+makeSem ''History
 
 
 spec :: Spec
-spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
+spec = describe "HistorySpec" $ it "should compile" $ do
+  let z = run . runState (0 :: Int) . runHistory $ do
+            modify (+ 5)
+            undo
+            x <- get
+            redo
+            y <- get
+            undo
+            put 1
+            redo
+            pure (x, y)
+  z `shouldBe` (1 :: Int, (0 :: Int, 5 :: Int))
 
 
-runHistory :: Sem (State (Identity s) ': State s ': r) ()
-runHistory = do
-  s <- gets runIdentity
-  put s
+data Zipper a = Zipper [a] a [a]
+
+focusZ :: Zipper a -> a
+focusZ (Zipper _ a _) = a
+
+modifyZ :: (a -> a) -> Zipper a -> Zipper a
+modifyZ f (Zipper past a _) = Zipper (a : past) (f a) []
+
+goBack :: Zipper a -> Zipper a
+goBack z@(Zipper [] _ _) = z
+goBack (Zipper (p : ps) a fs) = Zipper ps p (a : fs)
+
+goForward :: Zipper a -> Zipper a
+goForward z@(Zipper _ _ []) = z
+goForward (Zipper ps a (f : fs)) = Zipper (a : ps) f fs
+
+runHistory
+    :: forall s r a
+     . Member (State s) r
+    => Sem (History s ': r) a
+    -> Sem r a
+runHistory m = do
+  s <- get
+  evalState (Zipper [] s [])
+    . interpret \case
+        Undo -> do
+          s' <- modify goBack >> gets focusZ
+          put s'
+        Redo -> do
+          s' <- modify goForward >> gets focusZ
+          put s'
+        PutAndForget s' ->
+          put s'
+    . intercept @(State s) \case
+        Get -> get
+        Put s' -> do
+          modify $ modifyZ $ const s'
+          put s'
+    . raiseUnder @(State (Zipper s))
+    $ m
 

--- a/polysemy-plugin/test/HistorySpec.hs
+++ b/polysemy-plugin/test/HistorySpec.hs
@@ -23,11 +23,11 @@ import Polysemy.State
 import Polysemy.Internal
 import Polysemy.Internal.Union
 import Data.Functor.Identity
--- import Test.Hspec
+import Test.Hspec
 
 
--- spec :: Spec
--- spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
+spec :: Spec
+spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
 
 
 runHistory :: Sem (State (Identity s) ': State s ': r) ()

--- a/polysemy-plugin/test/HistorySpec.hs
+++ b/polysemy-plugin/test/HistorySpec.hs
@@ -23,15 +23,14 @@ import Polysemy.State
 import Polysemy.Internal
 import Polysemy.Internal.Union
 import Data.Functor.Identity
-import Test.Hspec
+-- import Test.Hspec
 
 
-spec :: Spec
-spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
+-- spec :: Spec
+-- spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
 
 
-runHistory
-    :: Sem (State (Identity s) ': State s ': r) ()
+runHistory :: Sem (State (Identity s) ': State s ': r) ()
 runHistory = do
   s <- gets runIdentity
   put s

--- a/polysemy-plugin/test/HistorySpec.hs
+++ b/polysemy-plugin/test/HistorySpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
@@ -66,7 +65,7 @@ runHistory
 runHistory m = do
   s <- get
   evalState (Zipper [] s [])
-    . interpret \case
+    . interpret (\case
         Undo -> do
           s' <- modify goBack >> gets focusZ
           put s'
@@ -74,12 +73,12 @@ runHistory m = do
           s' <- modify goForward >> gets focusZ
           put s'
         PutAndForget s' ->
-          put s'
-    . intercept @(State s) \case
+          put s')
+    . intercept @(State s) (\case
         Get -> get
         Put s' -> do
           modify $ modifyZ $ const s'
-          put s'
+          put s')
     . raiseUnder @(State (Zipper s))
     $ m
 

--- a/polysemy-plugin/test/HistorySpec.hs
+++ b/polysemy-plugin/test/HistorySpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC
+     -fplugin=Polysemy.Plugin
+     -fdefer-type-errors
+     #-}
+
+module HistorySpec where
+
+import Polysemy
+import Polysemy.State
+import Polysemy.Internal
+import Polysemy.Internal.Union
+import Data.Functor.Identity
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
+
+
+runHistory
+    :: Sem (State (Identity s) ': State s ': r) ()
+runHistory = do
+  s <- gets runIdentity
+  put s
+

--- a/polysemy-plugin/test/SpecificitySpec.hs
+++ b/polysemy-plugin/test/SpecificitySpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
@@ -11,9 +10,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
-{-# OPTIONS_GHC
-     -fplugin=Polysemy.Plugin
-     #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
 
 module SpecificitySpec where
 

--- a/polysemy-plugin/test/SpecificitySpec.hs
+++ b/polysemy-plugin/test/SpecificitySpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC
+     -fplugin=Polysemy.Plugin
+     #-}
+
+module SpecificitySpec where
+
+import Polysemy
+import Polysemy.State
+import Polysemy.Internal
+import Polysemy.Internal.Union
+import Test.Hspec
+import Data.Functor.Identity
+
+
+spec :: Spec
+spec = describe "HistorySpec" $ it "should compile" $ True `shouldBe` True
+
+foo :: Members [State s, State (Identity s)] r => Sem r ()
+foo = do
+  s <- get
+  put $ Identity s

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -134,7 +134,7 @@ type MemberWithError e r =
     -- `WhenStuck (IndexOf r _) _`, so if you change this, make sure to change
     -- the corresponding implementation in
     -- Polysemy.Plugin.Fundep.solveBogusError
-  , WhenStuck (IndexOf r (Found r e)) (AmbiguousSend r e)
+  -- , WhenStuck (IndexOf r (Found r e)) (AmbiguousSend r e)
 #endif
   )
 

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -134,7 +134,7 @@ type MemberWithError e r =
     -- `WhenStuck (IndexOf r _) _`, so if you change this, make sure to change
     -- the corresponding implementation in
     -- Polysemy.Plugin.Fundep.solveBogusError
-  -- , WhenStuck (IndexOf r (Found r e)) (AmbiguousSend r e)
+  , WhenStuck (IndexOf r (Found r e)) (AmbiguousSend r e)
 #endif
   )
 


### PR DESCRIPTION
This thing solves #219, #209, and #114 I am pretty sure. 

In interpreter mode, the plugin used to see rows like `State (Identity a) ': State a ': r`, with an action in `State a`, and then _incorrectly unify that thing with the first thing in the list `State (Identity a)`_. As a result, we'd ask for `Identity a ~ a`, which is infinite, and things would go wrong.

Now we instead collect all of the unifications we'd like to do, and only emit _the most specific one,_ as measured by number of type constructors in it. This will now only emit a `State (Identity a) ~ State (Identity s)`, and then unify the state we're looking for, plus the `a ~ s` that solves the other state action.

But the next problem is that we can't determine `IndexOf` in the row above, because `a` is a type variable, and so `IndexOf` is stuck, even though we know `IndexOf that_row (State a) ~ 'S 'Z`. So the plugin now also solves "stuck" `IndexOf`s of that form.

All of this means we can now happily introduce local effects that have type variables, for effects that are already known to be present in the row. And somehow it just works! Amazing!