### PR TITLE
Add a convenience atomicGets

### DIFF
--- a/src/Polysemy/AtomicState.hs
+++ b/src/Polysemy/AtomicState.hs
@@ -49,8 +49,6 @@ atomicGet :: forall s r
            . Member (AtomicState s) r
           => Sem r s
 
--- | Only the \"get\" part of this operation is atomic - 
--- the function call doesn't block other consumers of the state.
 atomicGets :: forall s s' r
             . Member (AtomicState s) r
            => (s -> s')

--- a/src/Polysemy/AtomicState.hs
+++ b/src/Polysemy/AtomicState.hs
@@ -8,6 +8,7 @@ module Polysemy.AtomicState
   , atomicState
   , atomicState'
   , atomicGet
+  , atomicGets
   , atomicPut
   , atomicModify
   , atomicModify'
@@ -47,6 +48,15 @@ atomicState :: forall s a r
 atomicGet :: forall s r
            . Member (AtomicState s) r
           => Sem r s
+
+-- | Only the \"get\" part of this operation is atomic - 
+-- the function call doesn't block other consumers of the state.
+atomicGets :: forall s s' r
+            . Member (AtomicState s) r
+           => (s -> s')
+           -> Sem r s'
+atomicGets = (<$> atomicGet)
+{-# INLINE atomicGets #-}
 
 -----------------------------------------------------------------------------
 -- | A variant of 'atomicState' in which the computation is strict in the new


### PR DESCRIPTION
Is there something wrong with having this?

Notably right now the "get" operation is atomic, but the function application isn't. I think this is the expected/desirable behaviour? Or should we go the other way around and have the function also be "atomic" by doing `snd <$> atomicState (id &&& f)`?