### PR TITLE
Added a type synonym Before to constrain order of effect interpretation

### DIFF
--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -4,6 +4,9 @@ module Polysemy
   , Member
   , Members
   , Before
+  , After
+  , Firstly
+  , Lastly
 
   -- * Running Sem
   , run

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -3,6 +3,7 @@ module Polysemy
     Sem ()
   , Member
   , Members
+  , Before
 
   -- * Running Sem
   , run

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -11,6 +11,9 @@ module Polysemy.Internal
   , Member
   , Members
   , Before
+  , After
+  , Firstly
+  , Lastly
   , send
   , embed
   , run

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -10,6 +10,7 @@ module Polysemy.Internal
   ( Sem (..)
   , Member
   , Members
+  , Before
   , send
   , embed
   , run

--- a/src/Polysemy/Internal/Union.hs
+++ b/src/Polysemy/Internal/Union.hs
@@ -16,6 +16,7 @@ module Polysemy.Internal.Union
   , Weaving (..)
   , Member
   , MemberWithError
+  , Before
   , weave
   , hoist
   -- * Building Unions
@@ -143,11 +144,30 @@ type MemberNoError e r =
   , e ~ IndexOf r (Found r e)
   )
 
+-------------------------------------------------------------------------------
+-- | A proof that the effect @e1@ is interpreted before the effect @e2@ in
+-- the stack @r@.
+type Before e1 e2 r = BeforeNoError e1 e2 r
+
+type BeforeNoError e1 e2 r =
+  ( Find r e1
+  , Find r e2
+  , e1 ~ IndexOf r (Found r e1)
+  , e2 ~ IndexOf r (Found r e2)
+  , Compare (Found r e1) (Found r e2) 'LT)
 
 ------------------------------------------------------------------------------
 -- | The kind of type-level natural numbers.
 data Nat = Z | S Nat
 
+------------------------------------------------------------------------------
+-- | A relation which allows us to assert relative order between two
+-- type-level natural numbers.
+class Compare (n :: Nat) (m :: Nat) (o :: Ordering)
+instance Compare 'Z 'Z 'EQ
+instance Compare 'Z ('S n) 'LT
+instance Compare ('S n) 'Z 'GT
+instance Compare n m o => Compare ('S n) ('S m) o 
 
 ------------------------------------------------------------------------------
 -- | A singleton for 'Nat'.


### PR DESCRIPTION
It is wonderful that we can separate our syntax from our semantics, and generalize over effect membership in a stack, but there are a number of cases in which this such extreme generality is undesirable. For instance, depending on where you put an `Error CustomException` in your stack, your code will have very different behavior. In fact, there are codebases you could ruin with a 2 line diff, by swapping 2 interpreters and running the same polymorphic code.

To fix this, I made the constraint `Before e1 e2 r` to enforce the fact that `e1` is interpreted in your effect stack `r` before `e2` is. Some other things one might want to add before merging this is `Firstly e r`, `Lastly e r`, `BeforeAll e1 es r`, `After e1 e2 r`, `AfterAll e1 es r`, but I have a work obligation super early and I don't feel like implementing, documenting, and testing all of that at the moment. Feel free to let me know if you are interested in adding this into the library and I can add these things and whatever else we want before merging it in.

Note: It may be interesting to see what you can do with QuantifiedConstraints in combination with this... Maybe nothing? I dunno, could be fun.