### PR TITLE
Use cabal-doctest

### DIFF
--- a/polysemy-plugin/Setup.hs
+++ b/polysemy-plugin/Setup.hs
@@ -1,2 +1,3 @@
-import Distribution.Simple
-main = defaultMain
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main = defaultMainWithDoctests "polysemy-plugin-test"

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -18,7 +18,7 @@ maintainer:     sandy@sandymaguire.me
 copyright:      2019 Sandy Maguire
 license:        BSD3
 license-file:   LICENSE
-build-type:     Simple
+build-type:     Custom
 extra-source-files:
     README.md
     ChangeLog.md
@@ -26,6 +26,12 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/isovector/polysemy
+
+custom-setup
+    setup-depends:
+        base
+      , Cabal
+      , cabal-doctest >=1.0.6 && <1.1
 
 library
   exposed-modules:

--- a/polysemy-plugin/test/DoctestSpec.hs
+++ b/polysemy-plugin/test/DoctestSpec.hs
@@ -5,23 +5,12 @@ module DoctestSpec where
 import Test.Hspec
 import Test.DocTest
 
+import Build_doctests (flags, pkgs, module_sources)
+
 spec :: Spec
-spec = parallel $ describe "Error messages" $ it "should pass the doctest" $ doctest
+spec = parallel $ describe "Error messages" $ it "should pass the doctest" $ doctest $
   [ "--fast"
   , "-fobject-code"
-  , "-XDataKinds"
-  , "-XDeriveFunctor"
-  , "-XFlexibleContexts"
-  , "-XGADTs"
-  , "-XLambdaCase"
-  , "-XPolyKinds"
-  , "-XRankNTypes"
-  , "-XScopedTypeVariables"
-  , "-XStandaloneDeriving"
-  , "-XTypeApplications"
-  , "-XTypeFamilies"
-  , "-XTypeOperators"
-  , "-XUnicodeSyntax"
 
 #if __GLASGOW_HASKELL__ < 806
   , "-XMonadFailDesugaring"
@@ -30,3 +19,30 @@ spec = parallel $ describe "Error messages" $ it "should pass the doctest" $ doc
 
   , "test/TypeErrors.hs"
   ]
+  <> pkgs
+  <> removeFlagSearchPathSrc flags
+
+-- | Designed to remove flags that add the "polysemy-plugin/src" directory. For
+-- example, it will remove the following flag:
+-- "-i/Users/bob/code/polysemy/polysemy-plugin/src".
+--
+-- This was done because the presence of this flag causes the following error:
+--   test/TypeErrors.hs:9: failure in expression `:set -fplugin=Polysemy.Plugin'
+--   expected:   
+--    but got: attempting to use module ‘main:Polysemy.Plugin’
+--    (.../polysemy/polysemy-plugin/src/Polysemy/Plugin.hs) which is not loaded.
+--
+-- Without this flag, the tests pass as expected. My understanding of GHC isn't
+-- great, so feel free to remove this function if you know of some way of making
+-- this flag a non-issue.
+removeFlagSearchPathSrc :: [String] -> [String]
+removeFlagSearchPathSrc = filter (not . isSrcSearchPath)
+  where
+    isSrcSearchPath flag = isSearchPathFlag flag && isSrcDir flag
+
+    isSearchPathFlag ('-':'i':_) = True
+    isSearchPathFlag _           = False
+
+    isSrcDir ('s':'r':c':[]) = True
+    isSrcDir (x:xs)          = isSrcDir xs
+    isSrcDir []              = False


### PR DESCRIPTION
- Haskell build tools run in slightly different environments (meaning different
  package databases are available).
- The nixpkgs build for polysemy-plugin is failing due to a missing package
  database, which causes the doctest to fail (more information here:
  https://github.com/NixOS/nixpkgs/issues/71164).
- By using cabal-doctest we can expose the Haskell packages required to the
  doctests no matter the build tool we're using (claim not tested on everything).