### PR TITLE
Add explicit quantifier for parameters on outputToTrace

### DIFF
--- a/src/Polysemy/Trace.hs
+++ b/src/Polysemy/Trace.hs
@@ -82,7 +82,8 @@ runTraceList = runOutputList . reinterpret (
 --
 -- @since 1.0.0.0
 outputToTrace
-  :: Member Trace r
+  :: forall w r a
+   . Member Trace r
   => (w -> String)
   -> Sem (Output w ': r) a
   -> Sem r a


### PR DESCRIPTION
Adding an explicit quantifier as requested on this comment https://github.com/polysemy-research/polysemy/pull/289#issuecomment-560953740 by @isovector 