### PR TITLE
Remove extra-deps that are now in resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,15 +5,7 @@ packages:
 - polysemy-plugin
 
 extra-deps:
-- aeson-1.4.3.0
-- bifunctors-5.5.4
 - dump-core-0.1.3.2
 - first-class-families-0.6.0.0
 - ghc-lib-0.20190204
-- inspection-testing-0.4.2
-- loopbreaker-0.1.1.1
 - monadLib-3.9
-- th-abstraction-0.3.1.0
-- unagi-chan-0.4.1.3
-- type-errors-0.2.0.0
-- type-errors-pretty-0.0.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,4 +8,3 @@ extra-deps:
 - dump-core-0.1.3.2
 - first-class-families-0.6.0.0
 - ghc-lib-0.20190204
-- monadLib-3.9


### PR DESCRIPTION
Thanks to #298 there are now some new things in our resolver, so we can remove them from `extra-deps`

Notably this bumps the following libraries:
* aeson: 1.4.3.0 -> 1.4.6.0
* bifunctors: 5.5.4 -> 5.5.6
* inspection-testing: 0.4.2 -> 0.4.2.2
* th-abstraction: 0.3.1.0 -> 0.3.1.0@rev:1