### PR TITLE
Bring back monadLib with a clarification comment

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,7 @@ packages:
 - polysemy-plugin
 
 extra-deps:
-- dump-core-0.1.3.2
 - first-class-families-0.6.0.0
 - ghc-lib-0.20190204
+- dump-core-0.1.3.2 # used when the dump-core flag is toggled
+- monadLib-3.10 # used by the dump-core library when the dump-core flag is toggled


### PR DESCRIPTION
Unknowingly removed it in #299 