### PR TITLE
Add zulip badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Build Status](https://api.travis-ci.org/polysemy-research/polysemy.svg?branch=master)](https://travis-ci.org/polysemy-research/polysemy)
 [![Hackage](https://img.shields.io/hackage/v/polysemy.svg?logo=haskell&label=polysemy)](https://hackage.haskell.org/package/polysemy)
 [![Hackage](https://img.shields.io/hackage/v/polysemy-plugin.svg?logo=haskell&label=polysemy-plugin)](https://hackage.haskell.org/package/polysemy-plugin)
+[![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://funprog.zulipchat.com/#narrow/stream/216942-Polysemy)
 
 ## Dedication
 


### PR DESCRIPTION
[Rendered](https://github.com/srid/polysemy/blob/patch-1/README.md#polysemy)

Funprog zulip has a dedicated stream for Polysemy where a number of discussions are taking place. Sandy is participating as well. So why not make it the official chat for the project?

https://github.com/srid/rib also uses it.