### PR TITLE
Move unreleased changes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 # Changelog for polysemy
 
 
+## Unreleased changes
+
+- Changed the tyvars of `fromEitherM`, `runErrorAsAnother`, `runEmbedded`,
+  `asks` and `gets`
+
+
 ## 1.3.0.0 (2020-02-14)
 
 ### Breaking Changes
@@ -281,8 +287,3 @@
 ## 0.1.0.0 (2019-04-11)
 
 - Initial release
-
-## Unreleased changes
-
-- Changed the tyvars of `fromEitherM`, `runErrorAsAnother`, `runEmbedded`,
-  `asks` and `gets`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 - Changed the tyvars of `fromEitherM`, `runErrorAsAnother`, `runEmbedded`,
   `asks` and `gets`
 
+- Add ability to `Cancel` to `Async` (thanks to @aidangilmore)
 
 ## 1.3.0.0 (2020-02-14)
 


### PR DESCRIPTION
Mostly concerned with moving them to the top of the changelog, so you can't easily miss them.
Also added one new thing to the section.