### PR TITLE
don't expose the implementation on Async

### DIFF
--- a/src/Polysemy/Async.hs
+++ b/src/Polysemy/Async.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 
 module Polysemy.Async
   ( -- * Effect
@@ -31,10 +32,10 @@ import           Polysemy.Final
 -- 'Polysemy.Error.Error' effect didn't fail locally.
 --
 -- @since 0.5.0.0
-data Async m a where
-  Async :: m a -> Async m (A.Async (Maybe a))
-  Await :: A.Async a -> Async m a
-  Cancel :: A.Async a -> Async m ()
+data Async (h :: * -> *) m a where
+  Async :: m a -> Async h m (h (Maybe a))
+  Await :: h a -> Async h m a
+  Cancel :: h a -> Async h m ()
 
 makeSem ''Async
 
@@ -43,9 +44,9 @@ makeSem ''Async
 -- | Perform a sequence of effectful actions concurrently.
 --
 -- @since 1.2.2.0
-sequenceConcurrently :: forall t r a. (Traversable t, Member Async r) =>
+sequenceConcurrently :: forall t h r a. (Traversable t, Member (Async h) r) =>
     t (Sem r a) -> Sem r (t (Maybe a))
-sequenceConcurrently t = traverse async t >>= traverse await
+sequenceConcurrently t = traverse (async @h) t >>= traverse await
 {-# INLINABLE sequenceConcurrently #-}
 
 ------------------------------------------------------------------------------
@@ -69,7 +70,7 @@ sequenceConcurrently t = traverse async t >>= traverse await
 -- @since 1.0.0.0
 asyncToIO
     :: Member (Embed IO) r
-    => Sem (Async ': r) a
+    => Sem (Async A.Async ': r) a
     -> Sem r a
 asyncToIO m = withLowerToIO $ \lower _ -> lower $
   interpretH
@@ -104,7 +105,7 @@ asyncToIO m = withLowerToIO $ \lower _ -> lower $
 --
 -- @since 1.2.0.0
 asyncToIOFinal :: Member (Final IO) r
-               => Sem (Async ': r) a
+               => Sem (Async A.Async ': r) a
                -> Sem r a
 asyncToIOFinal = interpretFinal $ \case
   Async m -> do
@@ -124,7 +125,7 @@ lowerAsync
     => (forall x. Sem r x -> IO x)
        -- ^ Strategy for lowering a 'Sem' action down to 'IO'. This is likely
        -- some combination of 'runM' and other interpreters composed via '.@'.
-    -> Sem (Async ': r) a
+    -> Sem (Async A.Async ': r) a
     -> Sem r a
 lowerAsync lower m = interpretH
     ( \case

--- a/src/Polysemy/Async.hs
+++ b/src/Polysemy/Async.hs
@@ -157,9 +157,8 @@ runAsync = interpretH
         ins <- getInspectorT
         sem <- runAsync <$> runT ma
         pure (inspect ins <$> sem <$ is)
-      Await sem -> do
-        is <- getInitialStateT
-        (<$ is) <$> raise sem
+      Await sem ->
+        pureT =<< raise sem
       Cancel _ -> pureT ()
     )
 {-# INLINE runAsync #-}

--- a/test/AsyncSpec.hs
+++ b/test/AsyncSpec.hs
@@ -2,6 +2,7 @@
 
 module AsyncSpec where
 
+import qualified Control.Concurrent.Async as A
 import Control.Concurrent.MVar
 import Control.Monad
 import Polysemy
@@ -23,7 +24,7 @@ spec = describe "async" $ do
             [ show n, "> ", msg ]
       ~[lock1, lock2] <- embed $
         replicateM 2 newEmptyMVar
-      a1 <- async $ do
+      a1 <- async @A.Async $ do
           v <- get @String
           message 1 v
           put $ reverse v
@@ -34,7 +35,7 @@ spec = describe "async" $ do
 
           get @String
 
-      void $ async $ do
+      void $ async @A.Async $ do
           embed $ takeMVar lock1
           get >>= message 2
           put "pong"

--- a/test/FinalSpec.hs
+++ b/test/FinalSpec.hs
@@ -3,6 +3,7 @@ module FinalSpec where
 
 import Test.Hspec
 
+import qualified Control.Concurrent.Async as A
 import Data.Either
 import Data.IORef
 
@@ -52,7 +53,7 @@ test1 = do
      n1 <- mkNode 1
      n2 <- mkNode 2
      linkNode n2 n1
-     aw <- async $ do
+     aw <- async @A.Async $ do
        linkNode n1 n2
        modify (++"hadabra")
        n2' <- follow n2
@@ -69,7 +70,7 @@ test2 =
   . errorToIOFinal
   . asyncToIOFinal
   $ do
-  fut <- async $ do
+  fut <- async @A.Async $ do
     trace "Global state semantics?"
   catch @() (trace "What's that?" *> throw ()) (\_ -> return ())
   _ <- await fut

--- a/test/OutputSpec.hs
+++ b/test/OutputSpec.hs
@@ -1,5 +1,6 @@
 module OutputSpec where
 
+import qualified Control.Concurrent.Async as A
 import Control.Concurrent.STM
 import Control.Exception (evaluate)
 
@@ -78,11 +79,11 @@ runOutput size = run . runOutputMonoid (:[]) . runOutputBatched size
 runOutputList' :: Sem '[Output Int] a -> ([Int], a)
 runOutputList' = run . runOutputList
 
-test1 :: Members '[Async, Output Int] r
+test1 :: Members '[Async A.Async, Output Int] r
      => Sem r ()
 test1 = do
   output @Int 1
-  a <- async $ do
+  a <- async @A.Async $ do
     output @Int 2
   _ <- await a
   return ()

--- a/test/WriterSpec.hs
+++ b/test/WriterSpec.hs
@@ -61,7 +61,7 @@ test4 = do
     tell "message "
     listen $ do
       tell "has been"
-      a <- async $ tell " received"
+      a <- async @A.Async $ tell " received"
       await a
   end <- readTVarIO tvar
   return (end, listened)
@@ -74,7 +74,7 @@ test5 = do
     tell "message "
     listen $ do
       tell "has been"
-      a <- async $ do
+      a <- async @A.Async $ do
         embedFinal $ takeMVar lock
         tell " received"
       return a
@@ -92,7 +92,7 @@ test6 = do
         tell "message "
         fmap snd $ listen @String $ do
           tell "has been"
-          a <- async $ do
+          a <- async @A.Async $ do
             embedFinal $ takeMVar lock
             tell " received"
           throw a


### PR DESCRIPTION
see #378. adds a parameter to Async that replaces A.Async.

Problem, of course, is that `async` now needs the plugin for inference to succeed.