### PR TITLE
simpler version of interpretH

### DIFF
--- a/test/HigherOrderSpec.hs
+++ b/test/HigherOrderSpec.hs
@@ -1,9 +1,20 @@
 module HigherOrderSpec where
 
+import Polysemy.Internal (send)
+import Polysemy.Internal.Combinators (interpretHSimple)
 import Polysemy
 import Polysemy.Reader
 import Test.Hspec
 
+data TestE :: Effect where
+  TestE :: m a -> (a -> m b) -> TestE m b
+
+interpretTestE :: InterpreterFor TestE r
+interpretTestE =
+  interpretHSimple $ \ lift call -> \case
+    TestE ma f -> do
+      a <- lift ma
+      call f a
 
 spec :: Spec
 spec = parallel $ describe "Reader local" $ do
@@ -13,4 +24,7 @@ spec = parallel $ describe "Reader local" $ do
                   local (++ "!") $ do
                     ask
     foo `shouldBe` "hello world!"
-
+  it "simple" $ do
+    r <- runM (interpretTestE (send (TestE (pure 5) (pure . (9 +)))))
+    print r
+    (14 :: Int) `shouldBe` r


### PR DESCRIPTION
a small suggestion for a version of `interpretH` that provides functions that take care of the ceremony for running the interpreter on the higher order thunk.
prompted by people displaying difficulties with dealing with that.