### PR TITLE
Simple variants of runT and bindT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,8 @@
 
 
 ## Unreleased changes
-* Added `InterpretersFor` as a shorthand for interpreters consuming multiple effects
+- Added `InterpretersFor` as a shorthand for interpreters consuming multiple effects
+- Added `runTSimple` and `bindTSimple`, which are simplified variants of `runT` and `bindT`
 
 ## 1.4.0.0 (2020-10-31)
 

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5b7f95eb8e97177f60ae7387f50e8594297ee64259fcac3310f3cc83edef6531
+-- hash: 9d61a6c298262f3e765c48ccc01f30cd9c328104777970c3529931c4d5c4ca22
 
 name:           polysemy
 version:        1.4.0.0
@@ -143,6 +143,7 @@ test-suite polysemy-test
       KnownRowSpec
       LawsSpec
       OutputSpec
+      TacticsSpec
       ThEffectSpec
       TypeErrors
       ViewSpec

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -137,10 +137,10 @@ module Polysemy
   , WithTactics
   , getInitialStateT
   , pureT
+  , runTSimple
+  , bindTSimple
   , runT
   , bindT
-  , runTH
-  , bindTH
   , getInspectorT
   , Inspector (..)
   ) where

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -139,6 +139,8 @@ module Polysemy
   , pureT
   , runT
   , bindT
+  , runTH
+  , bindTH
   , getInspectorT
   , Inspector (..)
   ) where

--- a/src/Polysemy/Internal/Combinators.hs
+++ b/src/Polysemy/Internal/Combinators.hs
@@ -172,6 +172,7 @@ reinterpretH f sem = Sem $ \k -> runSem sem $ \u ->
       fmap y $ usingSem k
              $ runTactics s (raiseUnder . d) v (reinterpretH f . d)
              $ f e
+{-# INLINE[3] reinterpretH #-}
 -- TODO(sandy): Make this fuse in with 'stateful' directly.
 
 

--- a/src/Polysemy/Internal/Tactics.hs
+++ b/src/Polysemy/Internal/Tactics.hs
@@ -158,6 +158,8 @@ runT na = do
 -- This is a less flexible but significantly simpler variant of 'runT'.
 -- Instead of returning a 'Sem' action corresponding to the provided action,
 -- 'runTSimple' runs the action immediately.
+--
+-- @since TODO
 runTSimple :: m a
               -- ^ The monadic action to lift. This is usually a parameter in your
               -- effect.
@@ -193,6 +195,8 @@ bindT f = send $ HoistInterpretation f
 -- This is a less flexible but significantly simpler variant of 'bindT'.
 -- Instead of returning a 'Sem' kleisli action corresponding to the
 -- provided kleisli action, 'bindTSimple' runs the kleisli action immediately.
+--
+-- @since TODO
 bindTSimple
     :: forall m f r e a b
      . (a -> m b)

--- a/test/TacticsSpec.hs
+++ b/test/TacticsSpec.hs
@@ -11,8 +11,8 @@ interpretTestE :: InterpreterFor TestE r
 interpretTestE =
   interpretH $ \case
     TestE ma f -> do
-      a <- runTH ma
-      bindTH f a
+      a <- runTSimple ma
+      bindTSimple f a
 
 spec :: Spec
 spec = parallel $ describe "runTH and bindTH" $ do

--- a/test/TacticsSpec.hs
+++ b/test/TacticsSpec.hs
@@ -1,0 +1,22 @@
+module TacticsSpec where
+
+import Polysemy
+import Polysemy.Internal (send)
+import Test.Hspec
+
+data TestE :: Effect where
+  TestE :: m a -> (a -> m b) -> TestE m b
+
+interpretTestE :: InterpreterFor TestE r
+interpretTestE =
+  interpretH $ \case
+    TestE ma f -> do
+      a <- runTH ma
+      bindTH f a
+
+spec :: Spec
+spec = parallel $ describe "runTH and bindTH" $ do
+  it "should act as expected" $ do
+    r <- runM (interpretTestE (send (TestE (pure 5) (pure . (9 +)))))
+    print r
+    (14 :: Int) `shouldBe` r


### PR DESCRIPTION
A modified variant of @tek's [simple `runT` and `bindT` implementation](https://github.com/tek/polysemy/commit/36325a2027c66de5eec8b1b9548eb3bd992f8645). In comparison, this version:

- Doesn't require any extra type variables
- Allows the new combinators to also be used in `reinterpretHn`, and not just in `interpretH`
- Calls the combinators `runTH` and `bindTH` instead of `interpretHO` and `interpretBindHO`.

This partially adresses #386.

These names of `runTH` and `bindTH` still aren't final unless we want them to be. 