### PR TITLE
`seqEitherT` and `seqMaybeT`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ custom-setup:
     - cabal-doctest >=1.0.6 && <1.1
 
 default-extensions:
+  - BlockArguments
   - DataKinds
   - DeriveFunctor
   - FlexibleContexts

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9d61a6c298262f3e765c48ccc01f30cd9c328104777970c3529931c4d5c4ca22
+-- hash: ffaf97c7796aa183e71f94aaca237e2f7b05439b62c19195a08428b06478164f
 
 name:           polysemy
 version:        1.4.0.0
@@ -92,7 +92,7 @@ library
       Paths_polysemy
   hs-source-dirs:
       src
-  default-extensions: DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
+  default-extensions: BlockArguments DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
   ghc-options: -Wall
   build-depends:
       QuickCheck >=2.11.3 && <3
@@ -154,7 +154,7 @@ test-suite polysemy-test
       Build_doctests
   hs-source-dirs:
       test
-  default-extensions: DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
+  default-extensions: BlockArguments DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover >=2.0
@@ -189,7 +189,7 @@ benchmark polysemy-bench
       Paths_polysemy
   hs-source-dirs:
       bench
-  default-extensions: DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
+  default-extensions: BlockArguments DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
   build-depends:
       QuickCheck >=2.11.3 && <3
     , async >=2.2 && <3

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -141,6 +141,8 @@ module Polysemy
   , bindTSimple
   , runT
   , bindT
+  , seqEitherT
+  , seqMaybeT
   , getInspectorT
   , Inspector (..)
   ) where

--- a/test/TacticsSpec.hs
+++ b/test/TacticsSpec.hs
@@ -2,6 +2,7 @@ module TacticsSpec where
 
 import Polysemy
 import Polysemy.Internal (send)
+import Polysemy.Internal.Tactics (seqEitherT, seqMaybeT)
 import Test.Hspec
 
 data TestE :: Effect where
@@ -14,9 +15,49 @@ interpretTestE =
       a <- runTSimple ma
       bindTSimple f a
 
+data TestSeq :: Effect where
+   SeqRight :: m a -> TestSeq m (Either String a)
+   SeqLeft :: m a -> TestSeq m (Either String a)
+   SeqJust :: m a -> TestSeq m (Maybe a)
+   SeqNothing :: m a -> TestSeq m (Maybe a)
+
+success :: Sem r a -> Sem r (Either String a)
+success =
+  fmap Right
+
+failure :: Sem r a -> Sem r (Either String a)
+failure =
+  (Left "failed" <$)
+
+interpretTestSeq :: InterpreterFor TestSeq r
+interpretTestSeq =
+  interpretH \case
+    SeqRight ma ->
+      seqEitherT =<< success (runTSimple ma)
+    SeqLeft ma ->
+      seqEitherT =<< failure (runTSimple ma)
+    SeqJust ma ->
+      seqMaybeT =<< fmap Just (runTSimple ma)
+    SeqNothing ma ->
+      seqMaybeT =<< (Nothing <$) (runTSimple ma)
+
 spec :: Spec
-spec = parallel $ describe "runTH and bindTH" $ do
-  it "should act as expected" $ do
-    r <- runM (interpretTestE (send (TestE (pure 5) (pure . (9 +)))))
-    print r
-    (14 :: Int) `shouldBe` r
+spec = parallel $ do
+  describe "runTSimple and bindTSimple" $ do
+    it "should act as expected" $ do
+      r <- runM (interpretTestE (send (TestE (pure 5) (pure . (9 +)))))
+      (14 :: Int) `shouldBe` r
+  describe "seqEitherT" $ do
+    it "should sequence a Right" $ do
+      r <- runM (interpretTestSeq (send (SeqRight (pure 5))))
+      (Right (5 :: Int)) `shouldBe` r
+    it "should sequence a Left" $ do
+      r <- runM (interpretTestSeq (send (SeqLeft (pure 5))))
+      (Left "failed") `shouldBe` r
+  describe "seqMaybeT" $ do
+    it "should sequence a Just" $ do
+      r <- runM (interpretTestSeq (send (SeqJust (pure 5))))
+      (Just (5 :: Int)) `shouldBe` r
+    it "should sequence a Nothing" $ do
+      r <- runM (interpretTestSeq (send (SeqNothing (pure 5))))
+      Nothing `shouldBe` r


### PR DESCRIPTION
Convenience combinators for the case where a higher-order interpreter
has to deal with `Either e (f a)`.