### PR TITLE
Core rewrite for new family of easy higher-order interpreters

### DIFF
--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9d61a6c298262f3e765c48ccc01f30cd9c328104777970c3529931c4d5c4ca22
+-- hash: 754ab355722062c11ee014b832c3c95ddeea81fec4242a5938436c0ca64383c8
 
 name:           polysemy
 version:        1.4.0.0
@@ -71,6 +71,7 @@ library
       Polysemy.Internal.TH.Common
       Polysemy.Internal.TH.Effect
       Polysemy.Internal.Union
+      Polysemy.Internal.WeaveClass
       Polysemy.Internal.Writer
       Polysemy.IO
       Polysemy.Law

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -107,6 +107,13 @@ module Polysemy
   , transform
 
     -- * Combinators for Interpreting Higher-Order Effects
+  , interpretNew
+  , interceptNew
+  , reinterpretNew
+  , reinterpret2New
+  , reinterpret3New
+
+    -- * Combinators for Interpreting Higher-Order Effects using the 'Tactical' enviroment
   , interpretH
   , interceptH
   , reinterpretH
@@ -123,6 +130,14 @@ module Polysemy
     -- * Composing IO-based Interpreters
   , (.@)
   , (.@@)
+
+    -- * 'RunH'
+    -- | When interpreting higher-order effects using 'interpretNew'
+    -- and friends, you can't execute higher-order "thunks" given my
+    -- the interpreted effect directly. Instead, these must be executed
+    -- using 'runH'.
+  , RunH
+  , runH
 
     -- * Tactics
     -- | Higher-order effects need to explicitly thread /other effects'/ state
@@ -143,6 +158,7 @@ module Polysemy
   , bindT
   , getInspectorT
   , Inspector (..)
+
   ) where
 
 import Polysemy.Final

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -133,7 +133,7 @@ module Polysemy
 
     -- * 'RunH'
     -- | When interpreting higher-order effects using 'interpretNew'
-    -- and friends, you can't execute higher-order "thunks" given my
+    -- and friends, you can't execute higher-order "thunks" given by
     -- the interpreted effect directly. Instead, these must be executed
     -- using 'runH'.
   , RunH

--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -133,7 +133,7 @@ module Polysemy
 
     -- * 'RunH'
     -- | When interpreting higher-order effects using 'interpretNew'
-    -- and friends, you can't execute higher-order "thunks" given by
+    -- and friends, you can't execute higher-order \"thunks\" given by
     -- the interpreted effect directly. Instead, these must be executed
     -- using 'runH'.
   , RunH

--- a/src/Polysemy/Bundle.hs
+++ b/src/Polysemy/Bundle.hs
@@ -43,9 +43,12 @@ sendBundle
   => Sem (e ': r) a
   -> Sem r a
 sendBundle = hoistSem $ \u -> case decomp u of
-  Right (Weaving e s wv ex ins) ->
+  Right (Weaving e mkT lwr ex) ->
     injWeaving $
-      Weaving (Bundle (membership @e @r') e) s (sendBundle @e @r' . wv) ex ins
+      Weaving (Bundle (membership @e @r') e)
+              (\n -> mkT (n . sendBundle @e @r'))
+              lwr
+              ex
   Left g -> hoist (sendBundle @e @r') g
 {-# INLINE sendBundle #-}
 
@@ -57,8 +60,8 @@ runBundle
   => Sem (Bundle r' ': r) a
   -> Sem (Append r' r) a
 runBundle = hoistSem $ \u -> hoist runBundle $ case decomp u of
-  Right (Weaving (Bundle pr e) s wv ex ins) ->
-    Union (extendMembership @_ @r pr) $ Weaving e s wv ex ins
+  Right (Weaving (Bundle pr e) mkT lwr ex) ->
+    Union (extendMembership @_ @r pr) $ Weaving e mkT lwr ex
   Left g -> weakenList @r' @r g
 {-# INLINE runBundle #-}
 
@@ -70,7 +73,7 @@ subsumeBundle
   => Sem (Bundle r' ': r) a
   -> Sem r a
 subsumeBundle = hoistSem $ \u -> hoist subsumeBundle $ case decomp u of
-  Right (Weaving (Bundle pr e) s wv ex ins) ->
-    Union (subsumeMembership pr) (Weaving e s wv ex ins)
+  Right (Weaving (Bundle pr e) mkT lwr ex) ->
+    Union (subsumeMembership pr) (Weaving e mkT lwr ex)
   Left g -> g
 {-# INLINE subsumeBundle #-}

--- a/src/Polysemy/IO.hs
+++ b/src/Polysemy/IO.hs
@@ -68,5 +68,5 @@ lowerEmbedded run_m (Sem m) = withLowerToIO $ \lower _ ->
               . liftSem
               $ hoist (lowerEmbedded run_m) x
 
-      Right (Weaving (Embed wd) s _ y _) ->
-        y <$> ((<$ s) <$> wd)
+      Right (Weaving (Embed wd) _ lwr ex) ->
+        ex <$> ((<$ mkInitState lwr) <$> wd)

--- a/src/Polysemy/Internal/Combinators.hs
+++ b/src/Polysemy/Internal/Combinators.hs
@@ -498,7 +498,7 @@ interpretNew h (Sem sem) = Sem $ \(k :: forall x. Union r (Sem r) x -> m x) ->
         in
           fmap ex $ lwr $ go1 (h e)
 
--- TODO (KingoftheHomeless): If performance matter, optimize the definitions
+-- TODO (KingoftheHomeless): If it matters, optimize the definitions
 -- below
 
 ------------------------------------------------------------------------------

--- a/src/Polysemy/Internal/Forklift.hs
+++ b/src/Polysemy/Internal/Forklift.hs
@@ -36,8 +36,8 @@ runViaForklift
     -> IO a
 runViaForklift chan = usingSem $ \u -> do
   case prj u of
-    Just (Weaving (Embed m) s _ ex _) ->
-      ex . (<$ s) <$> m
+    Just (Weaving (Embed m) _ lwr ex) ->
+      ex . (<$ mkInitState lwr) <$> m
     _ -> do
       mvar <- newEmptyMVar
       writeChan chan $ Forklift mvar u

--- a/src/Polysemy/Internal/Strategy.hs
+++ b/src/Polysemy/Internal/Strategy.hs
@@ -21,7 +21,7 @@ data Strategy m f n z a where
 -- is extremely similar.
 --
 -- @since 1.2.0.0
-type Strategic m n a = forall f. Functor f => Sem (WithStrategy m f n) (m (f a))
+type Strategic m n a = forall f. Traversable f => Sem (WithStrategy m f n) (m (f a))
 
 
 ------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ type WithStrategy m f n = '[Strategy m f n]
 -- 'Polysemy.Final.withWeavingToFinal'.
 --
 -- @since 1.2.0.0
-runStrategy :: Functor f
+runStrategy :: Traversable f
             => Sem '[Strategy m f n] a
             -> f ()
             -> (forall x. f (n x) -> m (f x))

--- a/src/Polysemy/Internal/Tactics.hs
+++ b/src/Polysemy/Internal/Tactics.hs
@@ -60,7 +60,7 @@ import Polysemy.Internal.Union
 --
 -- The @f@ type here is existential and corresponds to "whatever
 -- state the other effects want to keep track of." @f@ is always
--- a 'Functor'.
+-- a 'Traversable'.
 --
 -- @alloc'@, @dealloc'@ and @use'@ are now in a form that can be
 -- easily consumed by your interpreter. At this point, simply bind

--- a/src/Polysemy/Internal/WeaveClass.hs
+++ b/src/Polysemy/Internal/WeaveClass.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving, QuantifiedConstraints, TupleSections #-}
+{-# OPTIONS_HADDOCK not-home #-}
+module Polysemy.Internal.WeaveClass
+  ( MonadTransControl(..)
+  , controlT
+
+  , mkInitState
+  , mkDistrib
+  , Distrib(..)
+  , mkInspector
+
+  , ComposeT(..)
+  ) where
+
+import Control.Monad
+import Data.Coerce
+import Data.Functor.Identity
+import Data.Functor.Compose
+import Data.Tuple
+import Control.Monad.Trans
+import Control.Monad.Trans.Identity
+import Control.Monad.Trans.Maybe
+
+import qualified Control.Monad.Trans.Except as E
+import qualified Control.Monad.Trans.State.Lazy as LSt
+import qualified Control.Monad.Trans.State.Strict as SSt
+import qualified Control.Monad.Trans.Writer.Lazy as LWr
+
+-- | A variant of the classic @MonadTransControl@ class from @monad-control@,
+-- but with a small number of changes to make it more suitable with Polysemy's
+-- internals.
+class ( MonadTrans t
+      , forall z. Monad z => Monad (t z)
+      , Traversable (StT t)
+      )
+   => MonadTransControl t where
+  type StT t :: * -> *
+
+  hoistT :: (Monad m, Monad n)
+         => (forall x. m x -> n x)
+         -> t m a -> t n a
+  hoistT n m = controlT $ \lower -> n (lower m)
+  {-# INLINE hoistT #-}
+
+  liftWith :: Monad m
+           => ((forall z x. Monad z => t z x -> z (StT t x)) -> m a)
+           -> t m a
+
+  restoreT :: Monad m => m (StT t a) -> t m a
+
+controlT :: (MonadTransControl t, Monad m)
+         => ((forall z x. Monad z => t z x -> z (StT t x)) -> m (StT t a))
+         -> t m a
+controlT main = liftWith main >>= restoreT . pure
+{-# INLINE controlT #-}
+
+newtype ComposeT t (u :: (* -> *) -> * -> *) m a = ComposeT {
+    getComposeT :: t (u m) a
+  }
+  deriving (Functor, Applicative, Monad)
+
+instance ( MonadTrans t
+         , MonadTrans u
+         , forall m. Monad m => Monad (u m)
+         )
+      => MonadTrans (ComposeT t u) where
+  lift m = ComposeT (lift (lift m))
+
+instance ( MonadTransControl t
+         , MonadTransControl u
+         )
+      => MonadTransControl (ComposeT t u) where
+  type StT (ComposeT t u) = Compose (StT u) (StT t)
+
+  hoistT n (ComposeT m) = ComposeT (hoistT (hoistT n) m)
+
+  liftWith main = ComposeT $
+    liftWith $ \lowerT ->
+    liftWith $ \lowerU ->
+    main (\(ComposeT m) -> Compose <$> lowerU (lowerT m))
+
+  restoreT m = ComposeT (restoreT (restoreT (fmap getCompose m)))
+
+newtype Distrib f q m = Distrib (forall x. f (q x) -> m (f x))
+
+mkInitState :: Monad (t Identity)
+            => (t Identity () -> Identity (StT t ()))
+            -> StT t ()
+mkInitState lwr = runIdentity $ lwr (pure ())
+{-# INLINE mkInitState #-}
+
+mkDistrib :: (MonadTransControl t, Monad m)
+          => (forall n x. Monad n => (forall y. m y -> n y) -> q x -> t n x)
+          -> (forall z x. Monad z => t z x -> z (StT t x))
+          -> Distrib (StT t) q m
+mkDistrib mkT lwr = Distrib $ lwr . join . restoreT . return . fmap (mkT id)
+{-# INLINE mkDistrib #-}
+
+mkInspector :: Foldable f => f a -> Maybe a
+mkInspector = foldr (const . Just) Nothing
+{-# INLINE mkInspector #-}
+
+instance MonadTransControl IdentityT where
+  type StT IdentityT = Identity
+  hoistT = (coerce :: (m x -> n x) -> IdentityT m x -> IdentityT n x)
+
+  liftWith main = IdentityT (main (fmap Identity . runIdentityT))
+
+  restoreT = IdentityT . fmap runIdentity
+
+instance MonadTransControl (LSt.StateT s) where
+  type StT (LSt.StateT s) = (,) s
+
+  hoistT = LSt.mapStateT
+
+  liftWith main = LSt.StateT $ \s ->
+        (, s)
+    <$> main (\m -> swap <$> LSt.runStateT m s)
+
+  restoreT m = LSt.StateT $ \_ -> swap <$> m
+
+instance MonadTransControl (SSt.StateT s) where
+  type StT (SSt.StateT s) = (,) s
+
+  hoistT = SSt.mapStateT
+
+  liftWith main = SSt.StateT $ \s ->
+        (, s)
+    <$> main (\m -> swap <$!> SSt.runStateT m s)
+
+  restoreT m = SSt.StateT $ \_ -> swap <$!> m
+
+instance MonadTransControl (E.ExceptT e) where
+  type StT (E.ExceptT e) = Either e
+
+  hoistT = E.mapExceptT
+
+  liftWith main = lift $ main E.runExceptT
+
+  restoreT = E.ExceptT
+
+instance Monoid w => MonadTransControl (LWr.WriterT w) where
+  type StT (LWr.WriterT w) = (,) w
+
+  hoistT = LWr.mapWriterT
+
+  liftWith main = lift $ main (fmap swap . LWr.runWriterT)
+
+  restoreT m = LWr.WriterT (swap <$> m)
+
+
+instance MonadTransControl MaybeT where
+  type StT MaybeT = Maybe
+
+  hoistT = mapMaybeT
+
+  liftWith main = lift $ main runMaybeT
+
+  restoreT = MaybeT

--- a/src/Polysemy/Membership.hs
+++ b/src/Polysemy/Membership.hs
@@ -9,6 +9,7 @@ module Polysemy.Membership
   -- * Using membership
   , subsumeUsing
   , interceptUsing
+  , interceptUsingNew
   , interceptUsingH
   ) where
 

--- a/src/Polysemy/Output.hs
+++ b/src/Polysemy/Output.hs
@@ -32,6 +32,7 @@ import Data.Bifunctor (first)
 import Polysemy
 import Polysemy.State
 import Control.Monad (when)
+import Control.Monad.Trans
 
 import Polysemy.Internal.Union
 import Polysemy.Internal.Writer
@@ -107,9 +108,9 @@ runLazyOutputMonoid
     => (o -> m)
     -> Sem (Output o ': r) a
     -> Sem r (m, a)
-runLazyOutputMonoid f = interpretViaLazyWriter $ \(Weaving e s _ ex _) ->
+runLazyOutputMonoid f = interpretViaLazyWriter $ \(Weaving e _ lwr ex) ->
   case e of
-    Output o -> ex s <$ Lazy.tell (f o)
+    Output o -> fmap ex $ lwr $ lift $ Lazy.tell (f o)
 
 ------------------------------------------------------------------------------
 -- | Like 'runOutputMonoid', but right-associates uses of '<>'.

--- a/src/Polysemy/Tagged.hs
+++ b/src/Polysemy/Tagged.hs
@@ -48,8 +48,8 @@ tag
     => Sem (e ': r) a
     -> Sem r a
 tag = hoistSem $ \u -> case decomp u of
-  Right (Weaving e s wv ex ins) ->
-    injWeaving $ Weaving (Tagged @k e) s (tag @k . wv) ex ins
+  Right (Weaving e mkT lwr ex) ->
+    injWeaving $ Weaving (Tagged @k e) (\n -> mkT (n . tag @k)) lwr ex
   Left g -> hoist (tag @k) g
 {-# INLINE tag #-}
 
@@ -62,8 +62,8 @@ tagged
     -> Sem (Tagged k e ': r) a
 tagged = hoistSem $ \u ->
   case decompCoerce u of
-    Right (Weaving e s wv ex ins) ->
-      injWeaving $ Weaving (Tagged @k e) s (tagged @k . wv) ex ins
+    Right (Weaving e mkT lwr ex) ->
+      injWeaving $ Weaving (Tagged @k e) (\n -> mkT (n . tagged @k)) lwr ex
     Left g -> hoist (tagged @k) g
 {-# INLINE tagged #-}
 
@@ -79,8 +79,8 @@ untag
 -- but doing so probably worsens performance, as it hampers optimizations.
 -- Once GHC 8.10 rolls out, I will benchmark and compare.
 untag = hoistSem $ \u -> case decompCoerce u of
-  Right (Weaving (Tagged e) s wv ex ins) ->
-    Union Here (Weaving e s (untag . wv) ex ins)
+  Right (Weaving (Tagged e) mkT lwr ex) ->
+    Union Here (Weaving e (\n -> mkT (n . untag)) lwr ex)
   Left g -> hoist untag g
 {-# INLINE untag #-}
 
@@ -93,8 +93,8 @@ retag
     => Sem (Tagged k1 e ': r) a
     -> Sem r a
 retag = hoistSem $ \u -> case decomp u of
-  Right (Weaving (Tagged e) s wv ex ins) ->
-    injWeaving $ Weaving (Tagged @k2 e) s (retag @_ @k2 . wv) ex ins
+  Right (Weaving (Tagged e) mkT lwr ex) ->
+    injWeaving $ Weaving (Tagged @k2 e) (\n -> mkT $ n . retag @_ @k2) lwr ex
   Left g -> hoist (retag @_ @k2) g
 {-# INLINE retag #-}
 

--- a/src/Polysemy/Writer.hs
+++ b/src/Polysemy/Writer.hs
@@ -100,18 +100,18 @@ runLazyWriter
      . Monoid o
     => Sem (Writer o ': r) a
     -> Sem r (o, a)
-runLazyWriter = interpretViaLazyWriter $ \(Weaving e s wv ex ins) ->
+runLazyWriter = interpretViaLazyWriter $ \(Weaving e mkT lwr ex) ->
   case e of
-    Tell o   -> ex s <$ Lazy.tell o
+    Tell o   -> ex (mkInitState lwr) <$ Lazy.tell o
     Listen m -> do
-      let m' = wv (m <$ s)
+      let m' = lwr $ mkT id m
       ~(fa, o) <- Lazy.listen m'
       return $ ex $ (,) o <$> fa
     Pass m -> do
-      let m' = wv (m <$ s)
+      let m' = lwr $ mkT id m
       Lazy.pass $ do
         ft <- m'
-        let f = maybe id fst (ins ft)
+        let f = maybe id fst (mkInspector ft)
         return (ex $ snd <$> ft, f)
 {-# INLINE runLazyWriter #-}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.1
+resolver: lts-16.26
 
 packages:
 - .


### PR DESCRIPTION
This is the massive rework mentioned in #386 and https://github.com/polysemy-research/polysemy/pull/384#issuecomment-719587819.

This essentially switches `polysemy` from a `weave`-based to a `MonadTransControl`-based effect system, and miraculously does so without _any_ breakage to any existing interface (outside of internal modules). This rewrite is done in order to support a new family of higher-order interpreter combinators -- currently called `interpretNew` -- which let you run higher-order thunks through a simple embedding action `runH` -- no state threading required!

Note, though, that `MonadTransControl` is more or less equivalent to `weave`, and this system still inherits all of `weave`'s problems (_except_ the difficulty of writing higher-order interpreters). So although `polysemy` wouldn't _technically_ be `weave`-based any longer, I'd still be calling it `weave`-based since the difference is so small to the point of being irrelevant.

This fixes #386.

Part of the rewrite is strengthening the `Tactical` environment such that the effectful state is represented by a `Traversable` instead of a `Functor`. This is because you can expect the state of any well-behaved `MonadTransControl` to be `Traversable` (at the very least, every real-world example I've encountered is.) So this also fixes #367.