### PR TITLE
Add `Semigroup` and `Monoid` instances for `Sem`

### DIFF
--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -307,6 +307,11 @@ instance (Member Fail r) => MonadFail (Sem r) where
   fail = send . Fail
   {-# INLINE fail #-}
 
+instance Semigroup a => Semigroup (Sem f a) where
+  (<>) = liftA2 (<>)
+
+instance Monoid a => Monoid (Sem f a) where
+  mempty = pure mempty
 
 ------------------------------------------------------------------------------
 -- | This instance will only lift 'IO' actions. If you want to lift into some

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -307,9 +307,11 @@ instance (Member Fail r) => MonadFail (Sem r) where
   fail = send . Fail
   {-# INLINE fail #-}
 
+-- | @since TODO
 instance Semigroup a => Semigroup (Sem f a) where
   (<>) = liftA2 (<>)
 
+-- | @since TODO
 instance Monoid a => Monoid (Sem f a) where
   mempty = pure mempty
 


### PR DESCRIPTION
I don't feel strongly about this change, but I frequently use these lifted `Monoid` and `Semigroup` instances in my own coding

I also wasn't sure what `@since` annotations to add since I don't know what the next release number will be.