### PR TITLE
Plugin: Solve ambiguous types based on instances in scope

### DIFF
--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -77,6 +77,7 @@ test-suite polysemy-plugin-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      AmbiguousSpec
       BadSpec
       DoctestSpec
       ExampleSpec

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Stuff.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Stuff.hs
@@ -36,7 +36,6 @@ data PolysemyStuff (l :: LookupState) = PolysemyStuff
   , semTyCon          :: ThingOf l TyCon
   , ifStuckTyCon      :: ThingOf l TyCon
   , locateEffectTyCon :: ThingOf l TyCon
-  , numClass          :: ThingOf l Class
   }
 
 
@@ -44,11 +43,10 @@ data PolysemyStuff (l :: LookupState) = PolysemyStuff
 -- | All of the things we need to lookup.
 polysemyStuffLocations :: PolysemyStuff 'Locations
 polysemyStuffLocations = PolysemyStuff
-  { findClass         = ("polysemy", "Polysemy.Internal.Union",                  "Find")
-  , semTyCon          = ("polysemy", "Polysemy.Internal",                        "Sem")
-  , ifStuckTyCon      = ("polysemy", "Polysemy.Internal.CustomErrors.Redefined", "IfStuck")
-  , locateEffectTyCon = ("polysemy", "Polysemy.Internal.Union",                  "LocateEffect")
-  , numClass          = ("base",     "GHC.Num",                                  "Num")
+  { findClass         = ("Polysemy.Internal.Union",                  "Find")
+  , semTyCon          = ("Polysemy.Internal",                        "Sem")
+  , ifStuckTyCon      = ("Polysemy.Internal.CustomErrors.Redefined", "IfStuck")
+  , locateEffectTyCon = ("Polysemy.Internal.Union",                  "LocateEffect")
   }
 
 
@@ -81,12 +79,11 @@ polysemyStuff = do
 #endif
     _                -> pure ()
 
-  let PolysemyStuff a b c d e = polysemyStuffLocations
+  let PolysemyStuff a b c d = polysemyStuffLocations
   PolysemyStuff <$> doLookup a
                 <*> doLookup b
                 <*> doLookup c
                 <*> doLookup d
-                <*> doLookup e
 
 
 ------------------------------------------------------------------------------
@@ -99,7 +96,7 @@ data LookupState
 ------------------------------------------------------------------------------
 -- | HKD indexed by the 'LookupState'; used by 'PolysemyStuff'.
 type family ThingOf (l :: LookupState) (a :: Type) :: Type where
-  ThingOf 'Locations _ = (String, String, String)
+  ThingOf 'Locations _ = (String, String)
   ThingOf 'Things    a = a
 
 
@@ -118,8 +115,8 @@ instance CanLookup TyCon where
 ------------------------------------------------------------------------------
 -- | Transform a @'ThingOf' 'Locations@ into a @'ThingOf' 'Things@.
 doLookup :: CanLookup a => ThingOf 'Locations a -> TcPluginM (ThingOf 'Things a)
-doLookup (mdl, mdname, name) = do
-  md <- lookupModule (mkModuleName mdname) $ fsLit mdl
+doLookup (mdname, name) = do
+  md <- lookupModule (mkModuleName mdname) $ fsLit "polysemy"
   nm <- lookupName md $ mkTcOcc name
   lookupStrategy nm
 

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
@@ -54,12 +54,12 @@ mustUnify (InterpreterUse b) = b
 -- not allowed to unify with anything but themselves. This properly handles all
 -- cases in which we are unifying ambiguous [W] constraints (which are true
 -- type variables) against [G] constraints.
-canUnify
+unify
     :: SolveContext
     -> Type  -- ^ wanted
     -> Type  -- ^ given
-    -> Bool
-canUnify solve_ctx = (isJust .) . tryUnifyUnivarsButNotSkolems skolems
+    -> Maybe TCvSubst
+unify solve_ctx = tryUnifyUnivarsButNotSkolems skolems
   where
     skolems :: Set TyVar
     skolems =

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
@@ -2,6 +2,8 @@
 
 module Polysemy.Plugin.Fundep.Unification where
 
+import qualified Data.Set as S
+import Data.Set (Set)
 import           Data.Bool
 import           Data.Function (on)
 import           Data.Maybe (isJust)
@@ -22,7 +24,6 @@ import           GHC.Core.Unify
 import           Type
 import           Unify
 #endif
-
 
 
 ------------------------------------------------------------------------------

--- a/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
+++ b/polysemy-plugin/src/Polysemy/Plugin/Fundep/Unification.hs
@@ -2,8 +2,6 @@
 
 module Polysemy.Plugin.Fundep.Unification where
 
-import qualified Data.Set as S
-import Data.Set (Set)
 import           Data.Bool
 import           Data.Function (on)
 import           Data.Maybe (isJust)

--- a/polysemy-plugin/test/AmbiguousSpec.hs
+++ b/polysemy-plugin/test/AmbiguousSpec.hs
@@ -8,22 +8,22 @@ import Test.Hspec
 import Polysemy.State
 import Data.Monoid
 
--- ambiguous :: Members '[
---               State Int
---             , State String
---             ] r
---           => Sem r ()
--- ambiguous = put 10
+ambiguous :: Members '[
+              State Int
+            , State String
+            ] r
+          => Sem r ()
+ambiguous = put 10
 
 ambiguous1 :: Members '[State (Sum Int), State String] r => Sem r ()
 ambiguous1 = put mempty
 
--- ambiguous2 :: (Num String, Members '[State Int, State String] r) => Sem r ()
--- ambiguous2 = put 10
+ambiguous2 :: (Num String, Members '[State Int, State String] r) => Sem r ()
+ambiguous2 = put 10
 
--- spec :: Spec
--- spec = describe "example" $ do
---   it "should compile!" $ do
---     let z = run . runState 0 . runState "hello" $ ambiguous
---     z `shouldBe` (10, ("hello", ()))
+spec :: Spec
+spec = describe "example" $ do
+  it "should compile!" $ do
+    let z = run . runState 0 . runState "hello" $ ambiguous
+    z `shouldBe` (10, ("hello", ()))
 

--- a/polysemy-plugin/test/AmbiguousSpec.hs
+++ b/polysemy-plugin/test/AmbiguousSpec.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
+
+module AmbiguousSpec where
+
+import Polysemy
+import Test.Hspec
+import Polysemy.State
+
+ambiguous :: Members '[
+              State Int
+            , State String
+            ] r
+          => Sem r ()
+ambiguous = put 10
+
+spec :: Spec
+spec = describe "example" $ do
+  it "should compile!" $ do
+    let z = run . runState 0 . runState "hello" $ ambiguous
+    z `shouldBe` (10, ("hello", ()))
+

--- a/polysemy-plugin/test/AmbiguousSpec.hs
+++ b/polysemy-plugin/test/AmbiguousSpec.hs
@@ -6,17 +6,24 @@ module AmbiguousSpec where
 import Polysemy
 import Test.Hspec
 import Polysemy.State
+import Data.Monoid
 
-ambiguous :: Members '[
-              State Int
-            , State String
-            ] r
-          => Sem r ()
-ambiguous = put 10
+-- ambiguous :: Members '[
+--               State Int
+--             , State String
+--             ] r
+--           => Sem r ()
+-- ambiguous = put 10
 
-spec :: Spec
-spec = describe "example" $ do
-  it "should compile!" $ do
-    let z = run . runState 0 . runState "hello" $ ambiguous
-    z `shouldBe` (10, ("hello", ()))
+ambiguous1 :: Members '[State (Sum Int), State String] r => Sem r ()
+ambiguous1 = put mempty
+
+-- ambiguous2 :: (Num String, Members '[State Int, State String] r) => Sem r ()
+-- ambiguous2 = put 10
+
+-- spec :: Spec
+-- spec = describe "example" $ do
+--   it "should compile!" $ do
+--     let z = run . runState 0 . runState "hello" $ ambiguous
+--     z `shouldBe` (10, ("hello", ()))
 

--- a/polysemy-plugin/test/AmbiguousSpec.hs
+++ b/polysemy-plugin/test/AmbiguousSpec.hs
@@ -1,19 +1,27 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell             #-}
+{-# OPTIONS_GHC -fdefer-type-errors      #-}
 {-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
 
 module AmbiguousSpec where
 
-import Polysemy
-import Test.Hspec
-import Polysemy.State
+import Control.Monad.IO.Class (liftIO)
+import Data.Functor.Identity
 import Data.Monoid
+import Polysemy
+import Polysemy.Embed (runEmbedded)
+import Polysemy.State
+import Test.Hspec
+import Test.ShouldNotTypecheck
 
-ambiguous :: Members '[
-              State Int
-            , State String
-            ] r
-          => Sem r ()
-ambiguous = put 10
+
+uniquelyInt :: Members '[State Int , State String] r => Sem r ()
+uniquelyInt = put 10
+
+uniquelyString :: Members '[State Int , State String] r => Sem r ()
+uniquelyString = put mempty
+
+uniquelyIO :: Members '[Embed IO, Embed Identity] r => Sem r ()
+uniquelyIO = embed $ liftIO $ pure ()
 
 ambiguous1 :: Members '[State (Sum Int), State String] r => Sem r ()
 ambiguous1 = put mempty
@@ -21,9 +29,24 @@ ambiguous1 = put mempty
 ambiguous2 :: (Num String, Members '[State Int, State String] r) => Sem r ()
 ambiguous2 = put 10
 
+
 spec :: Spec
 spec = describe "example" $ do
-  it "should compile!" $ do
-    let z = run . runState 0 . runState "hello" $ ambiguous
+  it "should run uniquelyInt" $ do
+    let z = run . runState 0 . runState "hello" $ uniquelyInt
     z `shouldBe` (10, ("hello", ()))
+
+  it "should run uniquelyString" $ do
+    let z = run . runState 0 . runState "hello" $ uniquelyString
+    z `shouldBe` (0, ("", ()))
+
+  it "should run uniquelyIO" $ do
+    z <- runM . runEmbedded @Identity (pure . runIdentity) $ uniquelyIO
+    z `shouldBe` ()
+
+  it "should not typecheck ambiguous1" $ do
+    shouldNotTypecheck ambiguous1
+
+  it "should not typecheck ambiguous2" $ do
+    shouldNotTypecheck ambiguous2
 


### PR DESCRIPTION
This PR uses knowledge of in-scope [W] constraints to help solve otherwise ambiguous `Member` constraints. Eg if we have `Members [Embed IO, Embed Identity] r`, and are trying to solve `(Member (Embed m) r, MonadIO m)`, there is a unique choice of `m ~ IO` such that the program will typecheck.

Fixes #219 