### PR TITLE
Expose `send`

### DIFF
--- a/src/Polysemy.hs
+++ b/src/Polysemy.hs
@@ -68,6 +68,11 @@ module Polysemy
     -- readLine  :: 'Member' Console r => 'Sem' r String
     -- @
     --
+    -- Each of these generated definitions make use of 'send' in order to perform
+    -- the corresponding action of the effect. If you don't want to use
+    -- Template Haskell, you can write the necessary boilerplate yourself by
+    -- using 'send' directly.
+    --
     -- Effects which don't make use of the @m@ parameter are known as
     -- "first-order effects."
 
@@ -95,6 +100,7 @@ module Polysemy
     -- @
     --
     -- As you see, in the smart constructors, the @m@ parameter has become @'Sem' r@.
+  , send
   , makeSem
   , makeSem_
 

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -573,8 +573,23 @@ insertAt = hoistSem $ \u -> hoist (insertAt @index @inserted @head @oldTail) $
 
 
 ------------------------------------------------------------------------------
--- | Embed an effect into a 'Sem'. This is used primarily via
--- 'Polysemy.makeSem' to implement smart constructors.
+-- | Execute an action of an effect.
+--
+-- This is primarily used to create methods for actions of effects:
+--
+-- @
+-- data FooBar m a where
+--   Foo :: String -> m a -> FooBar m a
+--   Bar :: FooBar m Int
+--
+-- foo :: Member FooBar r => String -> Sem r a -> Sem r a
+-- foo s m = send (Foo s m)
+--
+-- bar :: Member FooBar r => Sem r Int
+-- bar = send Bar
+-- @
+--
+-- 'Polysemy.makeSem' allows you to eliminate this boilerplate.
 send :: Member e r => e (Sem r) a -> Sem r a
 send = liftSem . inj
 {-# INLINE[3] send #-}

--- a/src/Polysemy/Internal.hs
+++ b/src/Polysemy/Internal.hs
@@ -590,6 +590,8 @@ insertAt = hoistSem $ \u -> hoist (insertAt @index @inserted @head @oldTail) $
 -- @
 --
 -- 'Polysemy.makeSem' allows you to eliminate this boilerplate.
+--
+-- @since TODO
 send :: Member e r => e (Sem r) a -> Sem r a
 send = liftSem . inj
 {-# INLINE[3] send #-}


### PR DESCRIPTION
We've previously remarked that we _really_ shouldn't have `send` be internal. Too many times. I decided I wouldn't forget it this time around.

Also cleaned up the documentation a bit. The review pass is mostly for that.