### PR TITLE
Fix formatting issue in 'tag' documentation

### DIFF
--- a/src/Polysemy/Tagged.hs
+++ b/src/Polysemy/Tagged.hs
@@ -39,7 +39,7 @@ newtype Tagged k e m a where
 --             -> 'Sem' r a
 --             -> 'Sem' r a
 -- taggedLocal f m =
---   'tag' @k @('Polysemy.Reader.Reader' i) $ 'Polysemy.Reader.local' @i f ('raise' m)
+--   'tag' \@k \@('Polysemy.Reader.Reader' i) $ 'Polysemy.Reader.local' @i f ('raise' m)
 -- @
 --
 tag


### PR DESCRIPTION
https://hackage.haskell.org/package/polysemy-1.7.1.0/docs/Polysemy-Tagged.html#v:tag

Currently:
![image](https://user-images.githubusercontent.com/69002988/168903449-14c7bb41-ad94-4061-8793-e65b3d1bb9fe.png)

With this commit:

![image](https://user-images.githubusercontent.com/69002988/168903562-7331381d-42a0-4543-946a-795b01abccb1.png)
