### PR TITLE
add call site parameter to Scoped

### DIFF
--- a/src/Polysemy/Internal/Scoped.hs
+++ b/src/Polysemy/Internal/Scoped.hs
@@ -25,26 +25,69 @@ import Polysemy.Internal.Combinators (transform)
 --
 -- The constructors are not intended to be used directly; the smart constructor 'scoped' is used like a local
 -- interpreter for @effect@.
-data Scoped (resource :: Type) (effect :: Effect) :: Effect where
-  Run :: ∀ resource effect m a . resource -> effect m a -> Scoped resource effect m a
-  InScope :: ∀ resource effect m a . (resource -> m a) -> Scoped resource effect m a
+-- 'scoped' takes an argument of type @param@, which will be passed through to the interpreter, to be used by the
+-- resource allocation function.
+data Scoped (param :: Type) (resource :: Type) (effect :: Effect) :: Effect where
+  Run :: ∀ param resource effect m a . resource -> effect m a -> Scoped param resource effect m a
+  InScope :: ∀ param resource effect m a . param -> (resource -> m a) -> Scoped param resource effect m a
+
+-- |A convenience alias for a scope without parameters.
+type Scoped_ resource effect =
+  Scoped () resource effect
 
 -- |Constructor for 'Scoped', taking a nested program and transforming all instances of @effect@ to
--- @Scoped resource effect@.
+-- @'Scoped' param resource effect@ and wrapping the result with 'InScope'.
+--
+-- This allows the effective interpreter to bracket the nested program with a resource from a distance.
+--
+-- The value @param@ is passed to the interpreter.
 scoped ::
-  ∀ resource effect r .
-  Member (Scoped resource effect) r =>
+  ∀ param resource effect r .
+  Member (Scoped param resource effect) r =>
+  param ->
   InterpreterFor effect r
-scoped main =
-  send $ InScope @resource @effect \ resource ->
-    transform @effect (Run resource) main
+scoped param main =
+  send $ InScope @param @resource @effect param \ resource ->
+    transform @effect (Run @param resource) main
+{-# inline scoped #-}
+
+-- |Constructor for 'Scoped_', taking a nested program and transforming all instances of @effect@ to
+-- @'Scoped_' resource effect@ and wrapping the result with 'InScope'.
+--
+-- This allows the effective interpreter to bracket the nested program with a resource from a distance.
+scoped_ ::
+  ∀ resource effect r .
+  Member (Scoped_ resource effect) r =>
+  InterpreterFor effect r
+scoped_ =
+  scoped @() @resource ()
+{-# inline scoped_ #-}
+
+-- |Transform the parameters of a 'Scoped' program.
+--
+-- This allows incremental additions to the data passed to the interpreter, for example to create an API that permits
+-- different ways of running an effect with some fundamental parameters being supplied at scope creation and some
+-- optional or specific parameters being selected by the user downstream.
+rescope ::
+  ∀ param0 param1 resource effect r .
+  Member (Scoped param1 resource effect) r =>
+  (param0 -> param1) ->
+  InterpreterFor (Scoped param0 resource effect) r
+rescope fp =
+  transform \case
+    Run res e ->
+      Run @param1 res e
+    InScope p main ->
+      InScope (fp p) main
+{-# inline rescope #-}
 
 -- |Helper for @runScoped@.
-interpretH' ::
+interpretWeaving ::
   ∀ e r .
   (∀ x . Weaving e (Sem (e : r)) x -> Sem r x) ->
   InterpreterFor e r
-interpretH' h (Sem m) =
+interpretWeaving h (Sem m) =
   Sem \ k -> m $ decomp >>> \case
     Right wav -> runSem (h wav) k
-    Left g -> k $ hoist (interpretH' h) g
+    Left g -> k $ hoist (interpretWeaving h) g
+{-# inline interpretWeaving #-}

--- a/src/Polysemy/Internal/Scoped.hs
+++ b/src/Polysemy/Internal/Scoped.hs
@@ -59,8 +59,10 @@ import Polysemy.Internal.Union (Weaving, decomp, hoist)
 --
 -- > interpretWriteFile :: Member (Embed IO) => InterpreterFor (Scoped FilePath Handle Write) r
 -- > interpretWriteFile =
--- >   interpretScoped (\ name use -> bracket (openFile name WriteMode) hClose use) \ handle -> \case
--- >     Write line -> embed (Text.hPutStrLn handle line)
+-- >   interpretScoped allocator handler
+-- >   where
+-- >     allocator name use = bracket (openFile name WriteMode) hClose use
+-- >     handler fileHandle (Write line) = embed (Text.hPutStrLn fileHandle line)
 --
 -- Essentially, the @bracket@ is executed at the point where @scoped@ was called, wrapping the following block.
 -- When the second @scoped@ is executed, another call to @bracket@ is performed.

--- a/src/Polysemy/Internal/Scoped.hs
+++ b/src/Polysemy/Internal/Scoped.hs
@@ -72,8 +72,8 @@ import Polysemy.Internal.Union (Weaving, decomp, hoist)
 --
 -- This makes it possible to use an in-memory interpreter for testing:
 --
--- > interpretWriteMap :: Member (Output (FilePath, Text)) r => InterpreterFor (Scoped FilePath FilePath Write) r
--- > interpretWriteMap =
+-- > interpretWriteOutput :: Member (Output (FilePath, Text)) r => InterpreterFor (Scoped FilePath FilePath Write) r
+-- > interpretWriteOutput =
 -- >   interpretScoped (\ name use -> use name) \ name -> \case
 -- >     Write line -> output (name, line)
 --

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -92,7 +92,7 @@ interpretScopedAs resource =
 --
 -- @scopedInterpreter@ is a regular interpreter that is called with the @resource@ argument produced by @scope@.
 -- This is mostly useful if you want to reuse an interpreter that you cannot easily rewrite (like from another library).
--- If you have full control over the implementation, 'interpreterScoped' should be preferred.
+-- If you have full control over the implementation, 'interpreteScoped' should be preferred.
 --
 -- /Note/: This function will be called for each action in the program, so if the interpreter allocates any resources,
 -- they will be scoped to a single action. Move them to @withResource@ instead.

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -2,21 +2,86 @@ module Polysemy.Scoped (
   -- * Effect
   Scoped,
 
-  -- * Constructor
+  -- * Constructors
   scoped,
+  scoped_,
+  rescope,
 
   -- * Interpreters
-  runScoped,
-  runScopedAs,
   interpretScopedH,
+  interpretScopedH',
   interpretScoped,
   interpretScopedAs,
+  runScoped,
+  runScopedAs,
 ) where
 
 import Polysemy.Internal (InterpreterFor, Sem, liftSem, raise)
-import Polysemy.Internal.Scoped (Scoped (Run, InScope), scoped, interpretH')
-import Polysemy.Internal.Union (Weaving(Weaving), injWeaving)
-import Polysemy.Internal.Tactics (Tactical, runTactics)
+import Polysemy.Internal.Combinators (interpretH)
+import Polysemy.Internal.Scoped (Scoped (InScope, Run), interpretWeaving, rescope, scoped, scoped_)
+import Polysemy.Internal.Tactics (Tactical, runTactics, runTSimple, liftT)
+import Polysemy.Internal.Union (Weaving (Weaving), injWeaving)
+
+-- |Interpreter for 'Scoped', taking a @resource@ allocation function and a parameterized handler for the plain
+-- @effect@.
+--
+-- >>> runScoped withResource scopedHandler
+--
+-- @withResource@ is a callback function, allowing the user to acquire the resource for each program wrapped by 'scoped'
+-- using other effects, with an additional argument that contains the call site parameter passed to 'scoped'.
+--
+-- @scopedHandler@ is a handler like the one expected by 'interpretH' with an additional parameter that contains the
+-- @resource@ allocated by @withResource@.
+interpretScopedH ::
+  ∀ param resource effect r .
+  (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
+  (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r x) ->
+  InterpreterFor (Scoped param resource effect) r
+interpretScopedH withResource scopedHandler =
+  run
+  where
+    run :: InterpreterFor (Scoped param resource effect) r
+    run =
+      interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
+        Run resource act ->
+          ex <$> runTactics s (raise . run . wv) ins (run . wv) (scopedHandler resource act)
+        InScope param main ->
+          withResource param \ resource -> ex <$> run (wv (main resource <$ s))
+{-# inline interpretScopedH #-}
+
+-- |Variant of 'interpretScopedH' that allows the resource acquisition function to use 'Tactical'.
+interpretScopedH' ::
+  ∀ param resource effect r .
+  (∀ e m x . param -> (resource -> Tactical e m r x) -> Tactical e m r x) ->
+  (∀ r0 x . resource -> effect (Sem r0) x -> Tactical (Scoped param resource effect) (Sem r0) r x) ->
+  InterpreterFor (Scoped param resource effect) r
+interpretScopedH' withResource scopedHandler =
+  interpretH \case
+    Run resource act ->
+      scopedHandler resource act
+    InScope param main ->
+      withResource param \ resource ->
+        runTSimple (main resource)
+{-# inline interpretScopedH' #-}
+
+-- |First-order variant of 'interpretScopedH'.
+interpretScoped ::
+  ∀ param resource effect r .
+  (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
+  (∀ r0 x . resource -> effect (Sem r0) x -> Sem r x) ->
+  InterpreterFor (Scoped param resource effect) r
+interpretScoped withResource scopedHandler =
+  interpretScopedH withResource \ r e -> liftT (scopedHandler r e)
+{-# inline interpretScoped #-}
+
+-- |Variant of 'interpretScoped' in which the resource allocator is a plain action.
+interpretScopedAs ::
+  ∀ param resource effect r .
+  (param -> Sem r resource) ->
+  (∀ r0 x . resource -> effect (Sem r0) x -> Sem r x) ->
+  InterpreterFor (Scoped param resource effect) r
+interpretScopedAs resource =
+  interpretScoped \ p use -> use =<< resource p
 
 -- |Interpreter for 'Scoped', taking a @resource@ allocation function and a parameterized interpreter for the plain
 -- @effect@.
@@ -26,75 +91,34 @@ import Polysemy.Internal.Tactics (Tactical, runTactics)
 -- @withResource@ is a callback function, allowing the user to acquire the resource for each program from other effects.
 --
 -- @scopedInterpreter@ is a regular interpreter that is called with the @resource@ argument produced by @scope@.
+-- This is mostly useful if you want to reuse an interpreter that you cannot easily rewrite (like from another library).
+-- If you have full control over the implementation, 'interpreterScoped' should be preferred.
 --
 -- /Note/: This function will be called for each action in the program, so if the interpreter allocates any resources,
 -- they will be scoped to a single action. Move them to @withResource@ instead.
 runScoped ::
-  ∀ resource effect r .
-  (∀ x . (resource -> Sem r x) -> Sem r x) ->
+  ∀ param resource effect r .
+  (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
   (resource -> InterpreterFor effect r) ->
-  InterpreterFor (Scoped resource effect) r
+  InterpreterFor (Scoped param resource effect) r
 runScoped withResource scopedInterpreter =
   run
   where
-    run :: InterpreterFor (Scoped resource effect) r
+    run :: InterpreterFor (Scoped param resource effect) r
     run =
-      interpretH' \ (Weaving effect s wv ex ins) -> case effect of
+      interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
         Run resource act ->
           scopedInterpreter resource (liftSem $ injWeaving $ Weaving act s (raise . run . wv) ex ins)
-        InScope main ->
-          ex <$> withResource \ resource -> run (wv (main resource <$ s))
+        InScope param main ->
+          withResource param \ resource -> ex <$> run (wv (main resource <$ s))
+{-# inline runScoped #-}
 
 -- |Variant of 'runScoped' in which the resource allocator is a plain action.
 runScopedAs ::
-  ∀ resource effect r .
-  Sem r resource ->
+  ∀ param resource effect r .
+  (param -> Sem r resource) ->
   (resource -> InterpreterFor effect r) ->
-  InterpreterFor (Scoped resource effect) r
+  InterpreterFor (Scoped param resource effect) r
 runScopedAs resource =
-  runScoped \ f -> f =<< resource
-
--- |Variant of 'runScoped' that takes a higher-order handler instead of an interpreter.
-interpretScopedH ::
-  ∀ resource effect r .
-  (∀ x . (resource -> Sem r x) -> Sem r x) ->
-  (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r x) ->
-  InterpreterFor (Scoped resource effect) r
-interpretScopedH withResource scopedHandler =
-  run
-  where
-    run :: InterpreterFor (Scoped resource effect) r
-    run =
-      interpretH' \ (Weaving effect s wv ex ins) -> case effect of
-        Run resource act ->
-          ex <$> runTactics s (raise . run . wv) ins (run . wv) (scopedHandler resource act)
-        InScope main ->
-          ex <$> withResource \ resource -> run (wv (main resource <$ s))
-
--- |Variant of 'runScoped' that takes a handler instead of an interpreter.
-interpretScoped ::
-  ∀ resource effect r .
-  (∀ x . (resource -> Sem r x) -> Sem r x) ->
-  (∀ r0 x . resource -> effect (Sem r0) x -> Sem r x) ->
-  InterpreterFor (Scoped resource effect) r
-interpretScoped withResource scopedHandler =
-  run
-  where
-    run :: InterpreterFor (Scoped resource effect) r
-    run =
-      interpretH' \ (Weaving effect s wv ex _) -> case effect of
-        Run resource act -> do
-          x <- scopedHandler resource act
-          pure (ex (x <$ s))
-        InScope main ->
-          ex <$> withResource \ resource -> run (wv (main resource <$ s))
-
-
--- |Variant of 'interpretScoped' in which the resource allocator is a plain action.
-interpretScopedAs ::
-  ∀ resource effect r .
-  Sem r resource ->
-  (∀ r0 x . resource -> effect (Sem r0) x -> Sem r x) ->
-  InterpreterFor (Scoped resource effect) r
-interpretScopedAs resource =
-  interpretScoped \ f -> f =<< resource
+  runScoped \ p use -> use =<< resource p
+{-# inline runScopedAs #-}

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -25,7 +25,7 @@ import Polysemy.Internal.Union (Weaving (Weaving), injWeaving)
 -- |Interpreter for 'Scoped', taking a @resource@ allocation function and a parameterized handler for the plain
 -- @effect@.
 --
--- >>> runScoped withResource scopedHandler
+-- >>> interpretScopedH withResource scopedHandler
 --
 -- @withResource@ is a callback function, allowing the user to acquire the resource for each program wrapped by 'scoped'
 -- using other effects, with an additional argument that contains the call site parameter passed to 'scoped'.


### PR DESCRIPTION
Since we haven't cut a release since we added `Scoped` and I've added some features in the meantime, I thought I'd upstream them now because I find them very useful.

I split them in two PRs so we can discuss separately.

This one concerns scope parameters that are passed to the interpreter from the call site, allowing the user to supply configuration for the resources, for example a process config:

```haskell
withSystemProcess ::
  Member (Scoped (ProcessConfig () () ()) resource SystemProcess) r =>
  ProcessConfig () () () ->
  InterpreterFor SystemProcess r
withSystemProcess =
  scoped
```

which can then be used by the interpreter to create the process:

```haskell
withProcess ::
  ProcessConfig () () () ->
  (Process Handle Handle Handle -> Sem r a) ->
  Sem r a

interpretSystemProcess :: InterpreterFor (Scoped (ProcessConfig () () ()) (Process Handle Handle Handle) SystemProcess) r
interpretSystemProcess =
  interpretScoped withProcess \ process -> \case
    ReadStdout -> hGetSome (getStdout process) 4096
```

Opinions? I think it's rather straightforward and I ran into a lot of situations where I needed it.
I kept a type alias `Scoped_` for the parameterless version, do you think that's sensible?