### PR TITLE
add variants of interpretScoped that allow additional local effects

### DIFF
--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -96,8 +96,10 @@ interpretScopedAs resource =
 -- /Note/: It is necessary to specify the list of local interpreters with a type application; GHC won't be able to
 -- figure them out from the type of @withResource@:
 --
--- > interpretScopedWithH @[AtomicState Int, Reader Bool] withResource \ _ -> \case
--- >   SomeAction -> atomicPut . (> 0) =<< ask
+-- > interpretScopedWithH @[State Bool, Reader Int] withResource \ _ -> \case
+-- >   SomeAction -> put . (> 0) =<< ask
+-- > where
+-- >   withResource param use = runState False (runReader 5 (use ()))
 interpretScopedWithH ::
   ∀ extra param resource effect r r1 .
   r1 ~ (Append extra r) =>


### PR DESCRIPTION
This builds upon the other PR #455.

Essentially, it permits a scope handler to use local effects that are interpreted by the resource allocation function.
The implementation is pretty hacky, so I would appreciate some advice, @KingoftheHomeless.

I'm pretty sure that the `error` can never be hit unless `Run` is sent manually, but it would surely be nice to avoid it nonetheless.