### PR TITLE
Scoped without resource param

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -91,13 +91,12 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    build-tools:
-    - hspec-discover >= 2.0
     dependencies:
     - polysemy
     - inspection-testing >= 0.4.2 && < 0.5
     - hspec >= 2.6.0 && < 3
     - doctest >= 0.16.0.1 && < 0.19
+    - hspec-discover >= 2.0
     generated-other-modules:
     - Build_doctests
 

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -56,9 +56,8 @@ tests:
       ghc-options:
         - -dcore-lint
         - -dsuppress-all
-    build-tools:
-    - hspec-discover
     dependencies:
+    - hspec-discover
     - polysemy >= 1.3.0.0
     - polysemy-plugin
     - hspec >= 2.6.0 && < 3

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -108,8 +108,6 @@ test-suite polysemy-plugin-test
       TypeFamilies
       UnicodeSyntax
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -fplugin=Polysemy.Plugin
-  build-tool-depends:
-      hspec-discover:hspec-discover
   build-depends:
       base >=4.9 && <5
     , containers >=0.5 && <0.7
@@ -117,12 +115,13 @@ test-suite polysemy-plugin-test
     , ghc >=8.6.5 && <10
     , ghc-tcplugins-extra >=0.3 && <0.5
     , hspec >=2.6.0 && <3
+    , hspec-discover
     , inspection-testing >=0.4.2 && <0.5
     , polysemy >=1.3.0.0
     , polysemy-plugin
     , should-not-typecheck >=2.1.0 && <3
     , syb ==0.7.*
     , transformers >=0.5.2.0 && <0.6
-  default-language: Haskell2010
   if flag(corelint)
     ghc-options: -dcore-lint -dsuppress-all
+  default-language: Haskell2010

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -114,7 +114,6 @@ library
     , transformers >=0.5.2.0 && <0.6
     , type-errors >=0.2.0.0
     , unagi-chan >=0.4.0.0 && <0.5
-  default-language: Haskell2010
   if impl(ghc < 8.6)
     default-extensions:
         MonadFailDesugaring
@@ -126,6 +125,7 @@ library
   if impl(ghc < 8.2.2)
     build-depends:
         unsupported-ghc-version >1 && <1
+  default-language: Haskell2010
 
 test-suite polysemy-test
   type: exitcode-stdio-1.0
@@ -143,6 +143,7 @@ test-suite polysemy-test
       InterceptSpec
       KnownRowSpec
       OutputSpec
+      ScopedSpec
       TacticsSpec
       ThEffectSpec
       TypeErrors
@@ -170,8 +171,6 @@ test-suite polysemy-test
       TypeFamilies
       UnicodeSyntax
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-tool-depends:
-      hspec-discover:hspec-discover >=2.0
   build-depends:
       async >=2.2 && <3
     , base >=4.9 && <5
@@ -179,6 +178,7 @@ test-suite polysemy-test
     , doctest >=0.16.0.1 && <0.19
     , first-class-families >=0.5.0.0 && <0.9
     , hspec >=2.6.0 && <3
+    , hspec-discover >=2.0
     , inspection-testing >=0.4.2 && <0.5
     , mtl >=2.2.2 && <3
     , polysemy
@@ -189,8 +189,8 @@ test-suite polysemy-test
     , transformers >=0.5.2.0 && <0.6
     , type-errors >=0.2.0.0
     , unagi-chan >=0.4.0.0 && <0.5
-  default-language: Haskell2010
   if impl(ghc < 8.6)
     default-extensions:
         MonadFailDesugaring
         TypeInType
+  default-language: Haskell2010

--- a/src/Polysemy/Internal/Scoped.hs
+++ b/src/Polysemy/Internal/Scoped.hs
@@ -20,7 +20,7 @@ import Polysemy
 --
 -- For a longer exposition, see <https://www.tweag.io/blog/2022-01-05-polysemy-scoped/>.
 -- Note that the interface has changed since the blog post was published: The
--- @resource@ parameter is no longer necessary.
+-- @resource@ parameter no longer exists.
 --
 -- Resource allocation is performed by a function passed to
 -- 'Polysemy.Scoped.interpretScoped'.

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -44,18 +44,18 @@ interpretScopedH ::
   -- | A handler like the one expected by 'interpretH' with an additional
   -- parameter that contains the @resource@ allocated by the first argument.
   (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r x) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 interpretScopedH withResource scopedHandler =
-  go
+  go (errorWithoutStackTrace "top level run")
   where
-    go :: InterpreterFor (Scoped param resource effect) r
-    go =
+    go :: resource -> InterpreterFor (Scoped param effect) r
+    go resource =
       interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
-        Run resource act ->
-          ex <$> runTactics s (raise . go . wv) ins (go . wv)
+        Run act ->
+          ex <$> runTactics s (raise . go resource . wv) ins (go resource . wv)
             (scopedHandler resource act)
         InScope param main ->
-          withResource param \ resource -> ex <$> go (wv (main resource <$ s))
+          withResource param \ resource' -> ex <$> go resource' (wv (main <$ s))
 {-# inline interpretScopedH #-}
 
 -- | Variant of 'interpretScopedH' that allows the resource acquisition function
@@ -66,15 +66,19 @@ interpretScopedH' ::
     Tactical e (Sem r0) r x) ->
   (∀ r0 x .
     resource -> effect (Sem r0) x ->
-    Tactical (Scoped param resource effect) (Sem r0) r x) ->
-  InterpreterFor (Scoped param resource effect) r
+    Tactical (Scoped param effect) (Sem r0) r x) ->
+  InterpreterFor (Scoped param effect) r
 interpretScopedH' withResource scopedHandler =
-  interpretH \case
-    Run resource act ->
-      scopedHandler resource act
-    InScope param main ->
-      withResource param \ resource ->
-        runTSimple (main resource)
+  go (errorWithoutStackTrace "top level run")
+  where
+    go :: resource -> InterpreterFor (Scoped param effect) r
+    go resource =
+      interpretH \case
+        Run act ->
+          scopedHandler resource act
+        InScope param main ->
+          withResource param \ resource' ->
+            raise . go resource' =<< runT main
 {-# inline interpretScopedH' #-}
 
 -- | First-order variant of 'interpretScopedH'.
@@ -82,7 +86,7 @@ interpretScoped ::
   ∀ resource param effect r .
   (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
   (∀ m x . resource -> effect m x -> Sem r x) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 interpretScoped withResource scopedHandler =
   interpretScopedH withResource \ r e -> liftT (scopedHandler r e)
 {-# inline interpretScoped #-}
@@ -93,7 +97,7 @@ interpretScopedAs ::
   ∀ resource param effect r .
   (param -> Sem r resource) ->
   (∀ m x . resource -> effect m x -> Sem r x) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 interpretScopedAs resource =
   interpretScoped \ p use -> use =<< resource p
 {-# inline interpretScopedAs #-}
@@ -149,27 +153,27 @@ interpretScopedWithH ::
   (KnownList extra, r1 ~ Append extra r) =>
   (∀ x . param -> (resource -> Sem r1 x) -> Sem r x) ->
   (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r1 x) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 interpretScopedWithH withResource scopedHandler =
   interpretWeaving \case
     Weaving (InScope param main) s wv ex _ ->
-      ex <$> withResource param \ resource -> inScope $
+      ex <$> withResource param \ resource -> inScope resource $
         restack
           (injectMembership
-           (singList @'[Scoped param resource effect])
-           (singList @extra)) $ wv (main resource <$ s)
+           (singList @'[Scoped param effect])
+           (singList @extra)) $ wv (main <$ s)
     _ ->
       errorWithoutStackTrace "top level Run"
   where
-    inScope :: InterpreterFor (Scoped param resource effect) r1
-    inScope =
+    inScope :: resource -> InterpreterFor (Scoped param effect) r1
+    inScope resource =
       interpretWeaving \case
         Weaving (InScope param main) s wv ex _ ->
           restack (extendMembershipLeft (singList @extra))
-            (ex <$> withResource param \resource ->
-                inScope (wv (main resource <$ s)))
-        Weaving (Run resource act) s wv ex ins ->
-          ex <$> runTactics s (raise . inScope . wv) ins (inScope . wv)
+            (ex <$> withResource param \resource' ->
+                inScope resource' (wv (main <$ s)))
+        Weaving (Run act) s wv ex ins ->
+          ex <$> runTactics s (raise . inScope resource . wv) ins (inScope resource . wv)
             (scopedHandler resource act)
 {-# inline interpretScopedWithH #-}
 
@@ -193,7 +197,7 @@ interpretScopedWith ::
   (r1 ~ Append extra r, KnownList extra) =>
   (∀ x . param -> (resource -> Sem r1 x) -> Sem r x) ->
   (∀ m x . resource -> effect m x -> Sem r1 x) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 interpretScopedWith withResource scopedHandler =
   interpretScopedWithH @extra withResource \ r e -> liftT (scopedHandler r e)
 {-# inline interpretScopedWith #-}
@@ -209,7 +213,7 @@ interpretScopedWith_ ::
   (r1 ~ Append extra r, KnownList extra) =>
   (∀ x . param -> Sem r1 x -> Sem r x) ->
   (∀ m x . effect m x -> Sem r1 x) ->
-  InterpreterFor (Scoped param () effect) r
+  InterpreterFor (Scoped param effect) r
 interpretScopedWith_ withResource scopedHandler =
   interpretScopedWithH @extra (\ p f -> withResource p (f ())) \ () e -> liftT (scopedHandler e)
 {-# inline interpretScopedWith_ #-}
@@ -249,18 +253,18 @@ runScoped ::
   ∀ param resource effect r .
   (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
   (resource -> InterpreterFor effect r) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 runScoped withResource scopedInterpreter =
-  go
+  go (errorWithoutStackTrace "top level run")
   where
-    go :: InterpreterFor (Scoped param resource effect) r
-    go =
+    go :: resource -> InterpreterFor (Scoped param effect) r
+    go resource =
       interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
-        Run resource act ->
+        Run act ->
           scopedInterpreter resource
-            $ liftSem $ injWeaving $ Weaving act s (raise . go . wv) ex ins
+            $ liftSem $ injWeaving $ Weaving act s (raise . go resource . wv) ex ins
         InScope param main ->
-          withResource param \ resource -> ex <$> go (wv (main resource <$ s))
+          withResource param \ resource' -> ex <$> go resource' (wv (main <$ s))
 {-# inline runScoped #-}
 
 -- | Variant of 'runScoped' in which the resource allocator returns the resource
@@ -269,6 +273,6 @@ runScopedAs ::
   ∀ param resource effect r .
   (param -> Sem r resource) ->
   (resource -> InterpreterFor effect r) ->
-  InterpreterFor (Scoped param resource effect) r
+  InterpreterFor (Scoped param effect) r
 runScopedAs resource = runScoped \ p use -> use =<< resource p
 {-# inline runScopedAs #-}

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -46,6 +46,7 @@ interpretScopedH ::
   (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r x) ->
   InterpreterFor (Scoped param effect) r
 interpretScopedH withResource scopedHandler =
+  -- TODO investigate whether loopbreaker optimization is effective here
   go (errorWithoutStackTrace "top level run")
   where
     go :: resource -> InterpreterFor (Scoped param effect) r

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -36,7 +36,7 @@ import Polysemy.Internal.Tactics
 -- use the 'Tactical' environment and transforms the effect into other effects
 -- on the stack.
 interpretScopedH ::
-  ∀ param resource effect r .
+  ∀ resource param effect r .
   -- | A callback function that allows the user to acquire a resource for each
   -- computation wrapped by 'scoped' using other effects, with an additional
   -- argument that contains the call site parameter passed to 'scoped'.
@@ -136,7 +136,7 @@ interpretScopedAs resource =
 -- > interpretMState ::
 -- >   ∀ s r .
 -- >   Members [Resource, Embed IO] r =>
--- >   InterpreterFor (Scoped s (MVar ()) (MState s)) r
+-- >   InterpreterFor (Scoped s (MState s)) r
 -- > interpretMState =
 -- >   interpretScopedWithH @'[AtomicState s] withResource \ lock -> \case
 -- >     MState f ->
@@ -186,7 +186,7 @@ interpretScopedWithH withResource scopedHandler =
 -- > data SomeAction :: Effect where
 -- >   SomeAction :: SomeAction m ()
 -- >
--- > foo :: InterpreterFor (Scoped () () SomeAction) r
+-- > foo :: InterpreterFor (Scoped () SomeAction) r
 -- > foo =
 -- >   interpretScopedWith @[Reader Int, State Bool] localEffects \ () -> \case
 -- >     SomeAction -> put . (> 0) =<< ask @Int
@@ -250,7 +250,7 @@ interpretScopedWith_ withResource scopedHandler =
 --
 -- > runScoped (\ initial use -> use =<< embed (newTVarIO initial)) runAtomicStateTVar
 runScoped ::
-  ∀ param resource effect r .
+  ∀ resource param effect r .
   (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
   (resource -> InterpreterFor effect r) ->
   InterpreterFor (Scoped param effect) r
@@ -270,7 +270,7 @@ runScoped withResource scopedInterpreter =
 -- | Variant of 'runScoped' in which the resource allocator returns the resource
 -- rather tnen calling a continuation.
 runScopedAs ::
-  ∀ param resource effect r .
+  ∀ resource param effect r .
   (param -> Sem r resource) ->
   (resource -> InterpreterFor effect r) ->
   InterpreterFor (Scoped param effect) r

--- a/test/ScopedSpec.hs
+++ b/test/ScopedSpec.hs
@@ -1,0 +1,67 @@
+{-# language TemplateHaskell, DerivingStrategies, GeneralizedNewtypeDeriving #-}
+
+module ScopedSpec where
+
+import Control.Concurrent.STM
+import Polysemy
+import Polysemy.Scoped
+import Test.Hspec
+
+newtype Par =
+  Par { unPar :: Int }
+  deriving stock (Eq, Show)
+  deriving newtype (Num, Real, Enum, Integral, Ord)
+
+data E :: Effect where
+  E1 :: E m Int
+  E2 :: E m Int
+
+makeSem ''E
+
+data F :: Effect where
+  F :: F m Int
+
+makeSem ''F
+
+handleE ::
+  Member (Embed IO) r =>
+  TVar Int ->
+  E m a ->
+  Tactical effect m (F : r) a
+handleE tv = \case
+  E1 -> do
+    i1 <- embed (readTVarIO tv)
+    i2 <- f
+    pureT (i1 + i2 + 10)
+  E2 ->
+    pureT (-1)
+
+interpretF ::
+  Member (Embed IO) r =>
+  TVar Int ->
+  InterpreterFor F r
+interpretF tv =
+  interpret \ F -> do
+    embed (atomically (writeTVar tv 7))
+    pure 5
+
+scope ::
+  Member (Embed IO) r =>
+  Par ->
+  (TVar Int -> Sem (F : r) a) ->
+  Sem r a
+scope (Par n) use = do
+  tv <- embed (newTVarIO n)
+  interpretF tv (use tv)
+
+spec :: Spec
+spec = parallel do
+  describe "Scoped" do
+    it "local effects" do
+      (i1, i2) <- runM $ interpretScopedWithH @'[F] @(TVar Int) @Par @E scope handleE do
+        scoped @Par @E 20 do
+          i1 <- e1
+          i2 <- scoped @Par @E 23 e1
+          pure (i1, i2)
+      35 `shouldBe` i1
+      38 `shouldBe` i2


### PR DESCRIPTION
Since the `*With` interpreter uses `error` for the case that `Run` is encountered without a wrapping `InScope`, I realized that this would allow the resource to be visible in the interpreter only.
What do you think, @KingoftheHomeless @googleson78 ?
Bit awkward for sure, but not having to haul that parameter around everywhere would certainly be quite the increase in ergonomics.