### PR TITLE
failing test for scoped with interpreter switch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,8 @@
     `fixpointToFinal` instead.
 - Changed semantics of `errorToIOFinal` so that it no longer catches errors
   from other handlers of the same type.
+- The semantics of `runScoped` has been changed so that the provided interpreter
+  is now used only once per use of `scoped`, instead of each individual action.
 
 ### Other Changes
 
@@ -34,7 +36,9 @@
 - Removed the debug `dump-core` flag.
 - Introduced the new meta-effect `Scoped`, which allows running an interpreter locally whose implementation is deferred
   to a later stage.
-
+- Fixed a bug in various `Scoped` interpreters where any explicit recursive
+  interpretation of higher-order computations that the handler may perform are
+  ignored by the interpreter, and the original handler was reused instead.
 
 ## 1.7.1.0 (2021-11-23)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,22 @@
 
 ### Other Changes
 
+## 1.9.0.0 (2022-12-28)
+
+### Breaking Changes
+- Slightly modified the signatures of the various `Scoped` interpreters.
+
+### Other Changes
+- Added `runScopedNew`, a simple but powerful `Scoped` interpreter.
+  `runScopedNew` can be considered a sneak-peek of the future of `Scoped`,
+  which will eventually receive a major API rework to make it both simpler and
+  more expressive.
+- Fixed a bug in various `Scoped` interpreters where a `scoped` usage of an
+  effect always relied on the nearest enclosing use of `scoped` from the same
+  `Scoped` effect, rather than the `scoped` which handles the effect.
+- Added `Polysemy.Opaque`, a module for the `Opaque` effect newtype, meant as
+  a tool to wrap polymorphic effect variables so they don't jam up resolution of
+  `Member` constraints.
 - Expose the type alias `Scoped_` for a scoped effect without callsite parameters.
 
 ## 1.8.0.0 (2022-12-22)

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -122,6 +122,6 @@ test-suite polysemy-plugin-test
     , should-not-typecheck >=2.1.0 && <3
     , syb ==0.7.*
     , transformers >=0.5.2.0 && <0.6
+  default-language: Haskell2010
   if flag(corelint)
     ghc-options: -dcore-lint -dsuppress-all
-  default-language: Haskell2010

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -65,6 +65,7 @@ library
       Polysemy.IO
       Polysemy.Membership
       Polysemy.NonDet
+      Polysemy.Opaque
       Polysemy.Output
       Polysemy.Reader
       Polysemy.Resource
@@ -109,6 +110,7 @@ library
     , transformers >=0.5.2.0 && <0.6
     , type-errors >=0.2.0.0
     , unagi-chan >=0.4.0.0 && <0.5
+  default-language: Haskell2010
   if impl(ghc < 8.6)
     default-extensions:
         MonadFailDesugaring
@@ -116,7 +118,6 @@ library
   if impl(ghc < 8.2.2)
     build-depends:
         unsupported-ghc-version >1 && <1
-  default-language: Haskell2010
 
 test-suite polysemy-test
   type: exitcode-stdio-1.0
@@ -180,8 +181,8 @@ test-suite polysemy-test
     , transformers >=0.5.2.0 && <0.6
     , type-errors >=0.2.0.0
     , unagi-chan >=0.4.0.0 && <0.5
+  default-language: Haskell2010
   if impl(ghc < 8.6)
     default-extensions:
         MonadFailDesugaring
         TypeInType
-  default-language: Haskell2010

--- a/src/Polysemy/Opaque.hs
+++ b/src/Polysemy/Opaque.hs
@@ -1,0 +1,53 @@
+module Polysemy.Opaque (
+  -- * Effect
+  Opaque(..),
+
+  -- * Interpreters
+  toOpaque,
+  fromOpaque,
+  ) where
+
+import Polysemy
+
+-- | An effect newtype meant to be used to wrap polymorphic effect variables to
+-- prevent them from jamming up resolution of 'Polysemy.Member'.
+-- For example, consider:
+--
+-- @
+-- badPut :: 'Sem' (e ': 'Polysemy.State.State' () ': r) ()
+-- badPut = 'Polysemy.State.put' () -- error
+-- @
+--
+-- This fails to compile. This is because @e@ /could/ be
+-- @'Polysemy.State.State' ()@' -- in which case the 'Polysemy.State.put'
+-- should target it instead of the concretely provided
+-- @'Polysemy.State.State' ()@; as the compiler can't know for sure which effect
+-- should be targeted, the program is rejected.
+-- There are various ways to resolve this, including using 'raise' or
+-- 'Polysemy.Membership.subsumeUsing'. 'Opaque' provides another way:
+--
+-- @
+-- okPut :: 'Sem' (e ': 'Polysemy.State.State' () ': r) ()
+-- okPut = 'fromOpaque' ('Polysemy.State.put' ()) -- OK
+-- @
+--
+-- 'Opaque' is most useful as a tool for library writers, in the case where some
+-- function of the library requires the user to work with an effect stack
+-- containing some polymorphic effect variables. By wrapping the polymorphic
+-- effect variables using 'Opaque', users of the function can use effects as
+-- normal, without having to use 'raise' or 'Polysemy.Membership.subsumeUsing'
+-- in order to have 'Polysemy.Member' resolve. The various interpreters of
+-- 'Polysemy.Scoped.Scoped' are examples of such usage of 'Opaque'.
+--
+-- @since 1.9.0.0
+newtype Opaque (e :: Effect) m a = Opaque (e m a)
+
+-- | Wrap 'Opaque' around the top effect of the effect stack
+toOpaque :: Sem (e ': r) a -> Sem (Opaque e ': r) a
+toOpaque = rewrite Opaque
+{-# INLINE toOpaque #-}
+
+-- | Unwrap 'Opaque' around the top effect of the effect stack
+fromOpaque :: Sem (Opaque e ': r) a -> Sem (e ': r) a
+fromOpaque = rewrite (\(Opaque e) -> e)
+{-# INLINE fromOpaque #-}

--- a/src/Polysemy/Scoped.hs
+++ b/src/Polysemy/Scoped.hs
@@ -1,4 +1,4 @@
-{-# language AllowAmbiguousTypes #-}
+{-# language AllowAmbiguousTypes, BangPatterns #-}
 
 module Polysemy.Scoped (
   -- * Effect
@@ -11,6 +11,7 @@ module Polysemy.Scoped (
   rescope,
 
   -- * Interpreters
+  runScopedNew,
   interpretScopedH,
   interpretScopedH',
   interpretScoped,
@@ -22,6 +23,11 @@ module Polysemy.Scoped (
   runScopedAs,
 ) where
 
+import Data.Function ((&))
+import Data.Sequence (Seq(..))
+import qualified Data.Sequence as S
+
+import Polysemy.Opaque
 import Polysemy.Internal
 import Polysemy.Internal.Sing
 import Polysemy.Internal.Union
@@ -41,25 +47,17 @@ interpretScopedH ::
   -- | A callback function that allows the user to acquire a resource for each
   -- computation wrapped by 'scoped' using other effects, with an additional
   -- argument that contains the call site parameter passed to 'scoped'.
-  (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
+  (∀ q x . param ->
+   (resource -> Sem (Opaque q ': r) x) ->
+   Sem (Opaque q ': r) x) ->
   -- | A handler like the one expected by 'interpretH' with an additional
   -- parameter that contains the @resource@ allocated by the first argument.
-  (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r x) ->
+  (∀ q r0 x . resource ->
+   effect (Sem r0) x ->
+   Tactical effect (Sem r0) (Opaque q ': r) x) ->
   InterpreterFor (Scoped param effect) r
-interpretScopedH withResource scopedHandler =
-  interpretWeaving $ \(Weaving effect s wv ex _) -> case effect of
-    Run _ -> errorWithoutStackTrace "top level run"
-    InScope param main -> withResource param \ resource ->
-          ex
-      <$> interpretH (scopedHandler resource) (go $ raiseUnder $ wv (main <$ s))
-  where
-    -- TODO investigate whether loopbreaker optimization is effective here
-    go :: InterpreterFor (Scoped param effect) (effect ': r)
-    go =
-      interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
-        Run act -> liftSem $ injWeaving $ Weaving act s (go . wv) ex ins
-        InScope param main -> raise $ withResource param \ resource ->
-          ex <$> interpretH (scopedHandler resource) (go $ wv (main <$ s))
+interpretScopedH withResource scopedHandler = runScopedNew \param sem ->
+  withResource param \r -> interpretH (scopedHandler r) sem
 {-# inline interpretScopedH #-}
 
 -- | Variant of 'interpretScopedH' that allows the resource acquisition function
@@ -73,26 +71,28 @@ interpretScopedH' ::
     Tactical (Scoped param effect) (Sem r0) r x) ->
   InterpreterFor (Scoped param effect) r
 interpretScopedH' withResource scopedHandler =
-  go (errorWithoutStackTrace "top level run")
+  go 0 Empty
   where
-    go :: resource -> InterpreterFor (Scoped param effect) r
-    go resource =
+    go :: Word -> Seq resource -> InterpreterFor (Scoped param effect) r
+    go depth resources =
       interpretH \case
-        Run act ->
-          scopedHandler resource act
-        InScope param main ->
-          withResource param \ resource' ->
-            raise . go resource' =<< runT main
+        Run w act ->
+          scopedHandler (S.index resources (fromIntegral w)) act
+        InScope param main | !depth' <- depth + 1 ->
+          withResource param \ resource ->
+            raise . go depth' (resources :|> resource) =<< runT (main depth)
 {-# inline interpretScopedH' #-}
 
 -- | First-order variant of 'interpretScopedH'.
 interpretScoped ::
   ∀ resource param effect r .
-  (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
+  (∀ q x . param ->
+   (resource -> Sem (Opaque q ': r) x) ->
+   Sem (Opaque q ': r) x) ->
   (∀ m x . resource -> effect m x -> Sem r x) ->
   InterpreterFor (Scoped param effect) r
 interpretScoped withResource scopedHandler =
-  interpretScopedH withResource \ r e -> liftT (scopedHandler r e)
+  interpretScopedH withResource \ r e -> liftT (raise (scopedHandler r e))
 {-# inline interpretScoped #-}
 
 -- | Variant of 'interpretScoped' in which the resource allocator is a plain
@@ -103,7 +103,7 @@ interpretScopedAs ::
   (∀ m x . resource -> effect m x -> Sem r x) ->
   InterpreterFor (Scoped param effect) r
 interpretScopedAs resource =
-  interpretScoped \ p use -> use =<< resource p
+  interpretScoped \ p use -> use =<< raise (resource p)
 {-# inline interpretScopedAs #-}
 
 -- | Higher-order interpreter for 'Scoped' that allows the handler to use
@@ -153,33 +153,24 @@ interpretScopedAs resource =
 -- >     MRead ->
 -- >       liftT atomicGet
 interpretScopedWithH ::
-  ∀ extra resource param effect r r1 .
-  (KnownList extra, r1 ~ Append extra r) =>
-  (∀ x . param -> (resource -> Sem r1 x) -> Sem r x) ->
-  (∀ r0 x . resource -> effect (Sem r0) x -> Tactical effect (Sem r0) r1 x) ->
+  ∀ extra resource param effect r .
+  KnownList extra =>
+  (∀ q x .
+   param ->
+   (resource -> Sem (Append extra (Opaque q ': r)) x) ->
+   Sem (Opaque q ': r) x) ->
+  (∀ q r0 x .
+   resource ->
+   effect (Sem r0) x ->
+   Tactical effect (Sem r0) (Append extra (Opaque q ': r)) x) ->
   InterpreterFor (Scoped param effect) r
-interpretScopedWithH withResource scopedHandler =
-  interpretWeaving \case
-    Weaving (InScope param main) s wv ex _ ->
-      ex <$> withResource param \ resource ->
-        interpretH (scopedHandler resource) $ inScope $
-          restack
-            (injectMembership
-             (singList @'[Scoped param effect])
-             (singList @(effect ': extra))) $ wv (main <$ s)
-    _ ->
-      errorWithoutStackTrace "top level Run"
-  where
-    inScope :: InterpreterFor (Scoped param effect) (effect ': r1)
-    inScope =
-      interpretWeaving \case
-        Weaving (InScope param main) s wv ex _ ->
-          restack
-            (extendMembershipLeft (singList @(effect ': extra)))
-            (ex <$> withResource param \resource ->
-                interpretH (scopedHandler resource) $ inScope $ wv (main <$ s))
-        Weaving (Run act) s wv ex ins ->
-          liftSem $ injWeaving $ Weaving act s (inScope . wv) ex ins
+interpretScopedWithH withResource scopedHandler = runScopedNew
+  \param (sem :: Sem (effect ': Opaque q ': r) x) ->
+    withResource param \resource ->
+      sem
+        & restack
+           (injectMembership (singList @'[effect]) (singList @extra))
+        & interpretH (scopedHandler @q resource)
 {-# inline interpretScopedWithH #-}
 
 -- | First-order variant of 'interpretScopedWithH'.
@@ -198,13 +189,24 @@ interpretScopedWithH withResource scopedHandler =
 -- >   where
 -- >     localEffects () use = evalState False (runReader 5 (use ()))
 interpretScopedWith ::
-  ∀ extra param resource effect r r1 .
-  (r1 ~ Append extra r, KnownList extra) =>
-  (∀ x . param -> (resource -> Sem r1 x) -> Sem r x) ->
-  (∀ m x . resource -> effect m x -> Sem r1 x) ->
+  ∀ extra param resource effect r.
+  KnownList extra =>
+  (∀ q x .
+   param ->
+   (resource -> Sem (Append extra (Opaque q ': r)) x) ->
+   Sem (Opaque q ': r) x) ->
+  (∀ m x . resource -> effect m x -> Sem (Append extra r) x) ->
   InterpreterFor (Scoped param effect) r
-interpretScopedWith withResource scopedHandler =
-  interpretScopedWithH @extra withResource \ r e -> liftT (scopedHandler r e)
+interpretScopedWith withResource scopedHandler = runScopedNew
+  \param (sem :: Sem (effect ': Opaque q ': r) x) ->
+    withResource param \resource ->
+      sem
+        & restack
+           (injectMembership (singList @'[effect]) (singList @extra))
+        & interpretH \e -> liftT $
+            restack
+              (injectMembership @r (singList @extra) (singList @'[Opaque q]))
+              (scopedHandler resource e)
 {-# inline interpretScopedWith #-}
 
 -- | Variant of 'interpretScopedWith' in which no resource is used and the
@@ -214,13 +216,18 @@ interpretScopedWith withResource scopedHandler =
 --
 -- See the /Note/ on 'interpretScopedWithH'.
 interpretScopedWith_ ::
-  ∀ extra param effect r r1 .
-  (r1 ~ Append extra r, KnownList extra) =>
-  (∀ x . param -> Sem r1 x -> Sem r x) ->
-  (∀ m x . effect m x -> Sem r1 x) ->
+  ∀ extra param effect r .
+  KnownList extra =>
+  (∀ q x .
+   param ->
+   Sem (Append extra (Opaque q ': r)) x ->
+   Sem (Opaque q ': r) x) ->
+  (∀ m x . effect m x -> Sem (Append extra r) x) ->
   InterpreterFor (Scoped param effect) r
 interpretScopedWith_ withResource scopedHandler =
-  interpretScopedWithH @extra (\ p f -> withResource p (f ())) \ () e -> liftT (scopedHandler e)
+  interpretScopedWith @extra
+    (\ p f -> withResource p (f ()))
+    (\ () -> scopedHandler)
 {-# inline interpretScopedWith_ #-}
 
 -- | Variant of 'interpretScoped' that uses another interpreter instead of a
@@ -237,35 +244,85 @@ interpretScopedWith_ withResource scopedHandler =
 -- used only once per use of 'scoped', and have it cover the same scope of
 -- actions that the resource allocator does.
 --
--- This renders the resource allocator practically redundant; for the moment, the API
--- surrounding 'Scoped' remains the same, but work is in progress to revamp the
--- entire API of 'Scoped'.
+-- This renders the resource allocator practically redundant; for the moment,
+-- the API surrounding 'Scoped' remains the same, but work is in progress to
+-- revamp the entire API of 'Scoped'.
 runScoped ::
   ∀ resource param effect r .
-  (∀ x . param -> (resource -> Sem r x) -> Sem r x) ->
-  (resource -> InterpreterFor effect r) ->
+  (∀ q x . param -> (resource -> Sem (Opaque q ': r) x) -> Sem (Opaque q ': r) x) ->
+  (∀ q . resource -> InterpreterFor effect (Opaque q ': r)) ->
   InterpreterFor (Scoped param effect) r
-runScoped withResource scopedInterpreter =
-  interpretWeaving \(Weaving effect s wv ex _) -> case effect of
-    Run _ -> errorWithoutStackTrace "top level run"
-    InScope param main -> withResource param \ resource ->
-      ex <$> scopedInterpreter resource (go (raiseUnder $ wv (main <$ s)))
-  where
-    go :: InterpreterFor (Scoped param effect) (effect ': r)
-    go =
-      interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
-        Run act -> liftSem $ injWeaving $ Weaving act s (go . wv) ex ins
-        InScope param main ->
-          raise $ withResource param \ resource ->
-            ex <$> scopedInterpreter resource (go (wv (main <$ s)))
+runScoped withResource scopedInterpreter = runScopedNew \param sem ->
+  withResource param (\r -> scopedInterpreter r sem)
 {-# inline runScoped #-}
 
 -- | Variant of 'runScoped' in which the resource allocator returns the resource
--- rather tnen calling a continuation.
+-- rather than calling a continuation.
 runScopedAs ::
   ∀ resource param effect r .
   (param -> Sem r resource) ->
-  (resource -> InterpreterFor effect r) ->
+  (∀ q. resource -> InterpreterFor effect (Opaque q ': r)) ->
   InterpreterFor (Scoped param effect) r
-runScopedAs resource = runScoped \ p use -> use =<< resource p
+runScopedAs resource = runScoped \ p use -> use =<< raise (resource p)
 {-# inline runScopedAs #-}
+
+-- | Run a 'Scoped' effect by specifying the interpreter to be used at every
+-- use of 'scoped'.
+--
+-- This interpretation of 'Scoped' is powerful enough to subsume all other
+-- interpretations of 'Scoped' (except 'interpretScopedH'' which works
+-- differently from all other interpretations) while also being much simpler.
+--
+-- Consider this a sneak-peek of the future of 'Scoped'. In the API rework
+-- planned for 'Scoped', the effect and its interpreters will be further
+-- expanded to make 'Scoped' even more flexible.
+--
+-- @since 1.9.0.0
+runScopedNew ::
+  ∀ param effect r .
+  (∀ q. param -> InterpreterFor effect (Opaque q ': r)) ->
+  InterpreterFor (Scoped param effect) r
+runScopedNew h =
+  interpretWeaving $ \(Weaving effect s wv ex _) -> case effect of
+    Run w _ -> errorWithoutStackTrace $ "top level run with depth " ++ show w
+    InScope param main ->
+      wv (main 0 <$ s)
+        & raiseUnder2
+        & go 0
+        & h param
+        & interpretH (\(Opaque (OuterRun w _)) ->
+            errorWithoutStackTrace $ "unhandled OuterRun with depth " ++ show w)
+        & fmap ex
+  where
+    go' :: Word
+        -> InterpreterFor
+             (Opaque (OuterRun effect))
+             (effect ': Opaque (OuterRun effect) ': r)
+    go' depth =
+      interpretWeaving \ (Weaving sr@(Opaque (OuterRun w act)) s wv ex ins) ->
+        if w == depth then
+          liftSem $ injWeaving $ Weaving act s (go' depth . wv) ex ins
+        else
+          liftSem $ injWeaving $ Weaving sr s (go' depth . wv) ex ins
+
+    -- TODO investigate whether loopbreaker optimization is effective here
+    go :: Word
+       -> InterpreterFor
+            (Scoped param effect)
+            (effect ': Opaque (OuterRun effect) ': r)
+    go depth =
+      interpretWeaving \ (Weaving effect s wv ex ins) -> case effect of
+        Run w act
+          | w == depth -> liftSem $ injWeaving $
+            Weaving act s (go depth . wv) ex ins
+          | otherwise -> liftSem $ injWeaving $
+            Weaving (Opaque (OuterRun w act)) s (go depth . wv) ex ins
+        InScope param main -> do
+          let !depth' = depth + 1
+          wv (main depth' <$ s)
+            & go depth'
+            & h param
+            & raiseUnder2
+            & go' depth
+            & fmap ex
+{-# INLINE runScopedNew #-}

--- a/test/ScopedSpec.hs
+++ b/test/ScopedSpec.hs
@@ -4,6 +4,7 @@ module ScopedSpec where
 
 import Control.Concurrent.STM
 import Polysemy
+import Polysemy.Internal.Tactics
 import Polysemy.Scoped
 import Test.Hspec
 
@@ -69,6 +70,26 @@ handleHO n () = \case
   Inc ma -> raise . interpretH (handleHO (n + 1) ()) =<< runT ma
   Ret -> pureT n
 
+data Esc :: Effect where
+  Esc :: Esc m Int
+makeSem ''Esc
+
+data Indirect :: Effect where
+  Indirect :: Indirect m Int
+makeSem ''Indirect
+
+interpretIndirect :: Member Esc r => InterpreterFor Indirect r
+interpretIndirect = interpret \ Indirect -> esc
+
+handleEsc :: Int -> Esc m a -> Sem r a
+handleEsc i = \ Esc -> pure i
+
+test_escape :: Sem (Scoped Int Esc ': r) Int
+test_escape =
+    scoped @Int @Esc 2
+  $ interpretIndirect
+  $ scoped @Int @Esc 1 indirect
+
 spec :: Spec
 spec = parallel do
   describe "Scoped" do
@@ -78,11 +99,19 @@ spec = parallel do
           i1 <- e1
           i2 <- scoped @Par @E 23 e1
           pure (i1, i2)
-      35 `shouldBe` i1
-      38 `shouldBe` i2
+      i1 `shouldBe` 35
+      i2 `shouldBe` 38
     it "switch interpreter" do
       r <- runM $ interpretScopedH scopeHO (handleHO 1) do
         scoped_ @HO do
           inc do
             ret
-      2 `shouldBe` r
+      r `shouldBe` 2
+    it "scoped depth" do
+      r <- runM $ interpretScoped (flip ($)) handleEsc $ test_escape
+      r `shouldBe` 2
+      r' <- runM $ interpretScopedH'
+                    (\r h -> h r)
+                    (\i e -> liftT (handleEsc i e))
+                 $ test_escape
+      r' `shouldBe` 2


### PR DESCRIPTION
@KingoftheHomeless can you explain why this fails? Shouldn't the higher-order computation arrive in the handler untouched by the scope machinery?