### PR TITLE
Fix scoped within scoped incoherency. Add `runScopedNew`

### DIFF
--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -122,6 +122,6 @@ test-suite polysemy-plugin-test
     , should-not-typecheck >=2.1.0 && <3
     , syb ==0.7.*
     , transformers >=0.5.2.0 && <0.6
+  default-language: Haskell2010
   if flag(corelint)
     ghc-options: -dcore-lint -dsuppress-all
-  default-language: Haskell2010

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -65,6 +65,7 @@ library
       Polysemy.IO
       Polysemy.Membership
       Polysemy.NonDet
+      Polysemy.Opaque
       Polysemy.Output
       Polysemy.Reader
       Polysemy.Resource
@@ -109,6 +110,7 @@ library
     , transformers >=0.5.2.0 && <0.6
     , type-errors >=0.2.0.0
     , unagi-chan >=0.4.0.0 && <0.5
+  default-language: Haskell2010
   if impl(ghc < 8.6)
     default-extensions:
         MonadFailDesugaring
@@ -116,7 +118,6 @@ library
   if impl(ghc < 8.2.2)
     build-depends:
         unsupported-ghc-version >1 && <1
-  default-language: Haskell2010
 
 test-suite polysemy-test
   type: exitcode-stdio-1.0
@@ -180,8 +181,8 @@ test-suite polysemy-test
     , transformers >=0.5.2.0 && <0.6
     , type-errors >=0.2.0.0
     , unagi-chan >=0.4.0.0 && <0.5
+  default-language: Haskell2010
   if impl(ghc < 8.6)
     default-extensions:
         MonadFailDesugaring
         TypeInType
-  default-language: Haskell2010

--- a/src/Polysemy/Opaque.hs
+++ b/src/Polysemy/Opaque.hs
@@ -36,9 +36,10 @@ import Polysemy
 -- containing some polymorphic effect variables. By wrapping the polymorphic
 -- effect variables using 'Opaque', users of the function can use effects as
 -- normal, without having to use 'raise' or 'Polysemy.Membership.subsumeUsing'
--- in order to have 'Polysemy.Member' resolve.
+-- in order to have 'Polysemy.Member' resolve. The various interpreters of
+-- 'Polysemy.Scoped.Scoped' are examples of such usage of 'Opaque'.
 --
--- @since TODO
+-- @since 1.9.0.0
 newtype Opaque (e :: Effect) m a = Opaque (e m a)
 
 -- | Wrap 'Opaque' around the top effect of the effect stack

--- a/src/Polysemy/Opaque.hs
+++ b/src/Polysemy/Opaque.hs
@@ -1,0 +1,52 @@
+module Polysemy.Opaque (
+  -- * Effect
+  Opaque(..),
+
+  -- * Interpreters
+  toOpaque,
+  fromOpaque,
+  ) where
+
+import Polysemy
+
+-- | An effect newtype meant to be used to wrap polymorphic effect variables to
+-- prevent them from jamming up resolution of 'Polysemy.Member'.
+-- For example, consider:
+--
+-- @
+-- badPut :: 'Sem' (e ': 'Polysemy.State.State' () ': r) ()
+-- badPut = 'Polysemy.State.put' () -- error
+-- @
+--
+-- This fails to compile. This is because @e@ /could/ be
+-- @'Polysemy.State.State' ()@' -- in which case the 'Polysemy.State.put'
+-- should target it instead of the concretely provided
+-- @'Polysemy.State.State' ()@; as the compiler can't know for sure which effect
+-- should be targeted, the program is rejected.
+-- There are various ways to resolve this, including using 'raise' or
+-- 'Polysemy.Membership.subsumeUsing'. 'Opaque' provides another way:
+--
+-- @
+-- okPut :: 'Sem' (e ': 'Polysemy.State.State' () ': r) ()
+-- okPut = 'fromOpaque' ('Polysemy.State.put' ()) -- OK
+-- @
+--
+-- 'Opaque' is most useful as a tool for library writers, in the case where some
+-- function of the library requires the user to work with an effect stack
+-- containing some polymorphic effect variables. By wrapping the polymorphic
+-- effect variables using 'Opaque', users of the function can use effects as
+-- normal, without having to use 'raise' or 'Polysemy.Membership.subsumeUsing'
+-- in order to have 'Polysemy.Member' resolve.
+--
+-- @since TODO
+newtype Opaque (e :: Effect) m a = Opaque (e m a)
+
+-- | Wrap 'Opaque' around the top effect of the effect stack
+toOpaque :: Sem (e ': r) a -> Sem (Opaque e ': r) a
+toOpaque = rewrite Opaque
+{-# INLINE toOpaque #-}
+
+-- | Unwrap 'Opaque' around the top effet of the effect stack
+fromOpaque :: Sem (Opaque e ': r) a -> Sem (e ': r) a
+fromOpaque = rewrite (\(Opaque e) -> e)
+{-# INLINE fromOpaque #-}

--- a/test/ScopedSpec.hs
+++ b/test/ScopedSpec.hs
@@ -4,6 +4,7 @@ module ScopedSpec where
 
 import Control.Concurrent.STM
 import Polysemy
+import Polysemy.Internal.Tactics
 import Polysemy.Scoped
 import Test.Hspec
 
@@ -69,6 +70,26 @@ handleHO n () = \case
   Inc ma -> raise . interpretH (handleHO (n + 1) ()) =<< runT ma
   Ret -> pureT n
 
+data Esc :: Effect where
+  Esc :: Esc m Int
+makeSem ''Esc
+
+data Indirect :: Effect where
+  Indirect :: Indirect m Int
+makeSem ''Indirect
+
+interpretIndirect :: Member Esc r => InterpreterFor Indirect r
+interpretIndirect = interpret \ Indirect -> esc
+
+handleEsc :: Int -> Esc m a -> Sem r a
+handleEsc i = \ Esc -> pure i
+
+test_escape :: Sem (Scoped Int Esc ': r) Int
+test_escape =
+    scoped @Int @Esc 2
+  $ interpretIndirect
+  $ scoped @Int @Esc 1 indirect
+
 spec :: Spec
 spec = parallel do
   describe "Scoped" do
@@ -78,11 +99,19 @@ spec = parallel do
           i1 <- e1
           i2 <- scoped @Par @E 23 e1
           pure (i1, i2)
-      35 `shouldBe` i1
-      38 `shouldBe` i2
+      i1 `shouldBe` 35
+      i2 `shouldBe` 38
     it "switch interpreter" do
       r <- runM $ interpretScopedH scopeHO (handleHO 1) do
         scoped_ @HO do
           inc do
             ret
-      2 `shouldBe` r
+      r `shouldBe` 2
+    it "scoped depth" do
+      r <- runM $ interpretScoped (flip ($)) handleEsc $ test_escape
+      r `shouldBe` 2
+      r' <- runM $ interpretScopedH'
+                    (\r h -> h r)
+                    (\i e -> liftT (handleEsc i e))
+                 $ test_escape
+      r' `shouldBe` 2


### PR DESCRIPTION
The big question here is the `Opaque` pollution, which is breaking. There _is_ a way around that if we _desperately_ want to avoid it, but it won't be forward compatible with my Vision Of The Future Of `Scoped`, where `runScopedNew` (or something in its like) will be the primary `Scoped` interpreter.