### PR TITLE
README.md: update wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,4 +352,4 @@ implementation:
 [oleg:more]: http://okmij.org/ftp/Haskell/extensible/more.pdf
 [schrijvers:fusion]: https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf
 [wu:scope]: https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
-[flake]: https://nixos.wiki/wiki/Flakes
+[flake]: https://wiki.nixos.org/wiki/Flakes


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113