### PR TITLE
Support Cabal 3.12.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ description:         Please see the README on GitHub at <https://github.com/poly
 
 dependencies:
 - base >= 4.9 && < 5
-- containers >= 0.5 && < 0.7
+- containers >= 0.5 && < 0.8
 - mtl >= 2.2.2 && < 3
 - syb >= 0.7 && < 0.8
 - stm >= 2 && < 3
@@ -33,7 +33,7 @@ dependencies:
 custom-setup:
   dependencies:
     - base >= 4.9 && < 5
-    - Cabal <3.11
+    - Cabal <3.13
     - cabal-doctest >=1.0.6 && <1.1
 
 default-extensions:

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -23,12 +23,12 @@ dependencies:
 - polysemy >= 1.7
 - syb >= 0.7 && < 0.8
 - transformers >= 0.5.2.0 && < 0.7
-- containers >= 0.5 && < 0.7
+- containers >= 0.5 && < 0.8
 
 custom-setup:
   dependencies:
     - base >= 4.9 && < 5
-    - Cabal <3.11
+    - Cabal <3.13
     - cabal-doctest >=1.0.6 && <1.1
 
 library:

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -27,7 +27,7 @@ source-repository head
 
 custom-setup
   setup-depends:
-      Cabal <3.11
+      Cabal <3.13
     , base >=4.9 && <5
     , cabal-doctest >=1.0.6 && <1.1
 
@@ -65,7 +65,7 @@ library
       UnicodeSyntax
   build-depends:
       base >=4.9 && <5
-    , containers >=0.5 && <0.7
+    , containers >=0.5 && <0.8
     , ghc >=8.6.5 && <10
     , ghc-tcplugins-extra >=0.3 && <0.5
     , polysemy >=1.7
@@ -110,7 +110,7 @@ test-suite polysemy-plugin-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -fplugin=Polysemy.Plugin
   build-depends:
       base >=4.9 && <5
-    , containers >=0.5 && <0.7
+    , containers >=0.5 && <0.8
     , doctest >=0.16.0.1 && <0.23
     , ghc >=8.6.5 && <10
     , ghc-tcplugins-extra >=0.3 && <0.5

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -27,7 +27,7 @@ source-repository head
 
 custom-setup
   setup-depends:
-      Cabal <3.11
+      Cabal <3.13
     , base >=4.9 && <5
     , cabal-doctest >=1.0.6 && <1.1
 
@@ -100,7 +100,7 @@ library
   build-depends:
       async >=2.2 && <3
     , base >=4.9 && <5
-    , containers >=0.5 && <0.7
+    , containers >=0.5 && <0.8
     , first-class-families >=0.5.0.0 && <0.9
     , mtl >=2.2.2 && <3
     , stm ==2.*
@@ -166,7 +166,7 @@ test-suite polysemy-test
   build-depends:
       async >=2.2 && <3
     , base >=4.9 && <5
-    , containers >=0.5 && <0.7
+    , containers >=0.5 && <0.8
     , doctest >=0.16.0.1 && <0.23
     , first-class-families >=0.5.0.0 && <0.9
     , hspec >=2.6.0 && <3


### PR DESCRIPTION
Just bumped bounds. Compiles locally with latest `Cabal` now. Not sure how your CI determines the used Cabal version.