### PR TITLE
Allow inspection-testing 0.6

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -80,7 +80,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - polysemy
-    - inspection-testing >= 0.4.2 && < 0.6
+    - inspection-testing >= 0.4.2 && < 0.7
     - hspec >= 2.6.0 && < 3
     - doctest >= 0.16.0.1 && < 0.23
     - hspec-discover >= 2.0

--- a/polysemy-plugin/package.yaml
+++ b/polysemy-plugin/package.yaml
@@ -62,7 +62,7 @@ tests:
     - polysemy-plugin
     - hspec >= 2.6.0 && < 3
     - should-not-typecheck >= 2.1.0 && < 3
-    - inspection-testing >= 0.4.2 && < 0.6
+    - inspection-testing >= 0.4.2 && < 0.7
     - doctest >= 0.16.0.1 && < 0.23
     generated-other-modules:
     - Build_doctests

--- a/polysemy-plugin/polysemy-plugin.cabal
+++ b/polysemy-plugin/polysemy-plugin.cabal
@@ -116,7 +116,7 @@ test-suite polysemy-plugin-test
     , ghc-tcplugins-extra >=0.3 && <0.5
     , hspec >=2.6.0 && <3
     , hspec-discover
-    , inspection-testing >=0.4.2 && <0.6
+    , inspection-testing >=0.4.2 && <0.7
     , polysemy >=1.3.0.0
     , polysemy-plugin
     , should-not-typecheck >=2.1.0 && <3

--- a/polysemy.cabal
+++ b/polysemy.cabal
@@ -171,7 +171,7 @@ test-suite polysemy-test
     , first-class-families >=0.5.0.0 && <0.9
     , hspec >=2.6.0 && <3
     , hspec-discover >=2.0
-    , inspection-testing >=0.4.2 && <0.6
+    , inspection-testing >=0.4.2 && <0.7
     , mtl >=2.2.2 && <3
     , polysemy
     , stm ==2.*


### PR DESCRIPTION
The (possible) breaking change at
https://github.com/nomeata/inspection-testing/pull/81 shouldn't affect us.